### PR TITLE
Add frontmatter-based skill visibility control

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,6 +321,42 @@ Skills are discovered at startup from the configured directories. For each direc
 
 Each skill subdirectory must contain a `SKILL.md` file with YAML frontmatter including `name` and `description` fields.
 
+## Skill Visibility Control
+
+Control which skills appear in tools vs prompts using optional frontmatter fields:
+
+| Frontmatter | In Tool Description | In Prompts Menu | Use Case |
+|-------------|---------------------|-----------------|----------|
+| (default) | Yes | Yes | Normal skills |
+| `disable-model-invocation: true` | No | Yes | User-triggered workflows (deploy, commit) |
+| `user-invocable: false` | Yes | No | Background context (model auto-loads when relevant) |
+
+### Example: User-Only Skill
+
+Hide from model auto-discovery, require explicit user invocation via `/skill-name` prompt:
+
+```yaml
+---
+name: deploy
+description: Deploy to production
+disable-model-invocation: true
+---
+```
+
+### Example: Model-Only Skill
+
+Hide from prompts menu, model uses automatically when relevant:
+
+```yaml
+---
+name: codebase-context
+description: Background information about this codebase
+user-invocable: false
+---
+```
+
+Note: Resources (`skill://` URIs) always include all skills regardless of these settings, allowing explicit access when needed.
+
 ## Testing
 
 ### Manual Testing with MCP Inspector

--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -16,6 +16,8 @@ export interface SkillMetadata {
   name: string;
   description: string;
   path: string; // Full path to SKILL.md
+  disableModelInvocation?: boolean; // When true, exclude from tool description
+  userInvocable?: boolean; // When false, exclude from prompts (default: true)
 }
 
 /**
@@ -85,6 +87,8 @@ export function discoverSkills(skillsDir: string): SkillMetadata[] {
 
       const name = metadata.name;
       const description = metadata.description;
+      const disableModelInvocation = metadata["disable-model-invocation"];
+      const userInvocable = metadata["user-invocable"];
 
       if (typeof name !== "string" || !name.trim()) {
         console.error(`Skill at ${skillDir}: missing or invalid 'name' field`);
@@ -99,6 +103,8 @@ export function discoverSkills(skillsDir: string): SkillMetadata[] {
         name: name.trim(),
         description: description.trim(),
         path: skillMdPath,
+        disableModelInvocation: disableModelInvocation === true,
+        userInvocable: userInvocable !== false, // Default to true
       });
     } catch (error) {
       console.error(`Failed to parse skill at ${skillDir}:`, error);
@@ -175,4 +181,20 @@ export function createSkillMap(skills: SkillMetadata[]): Map<string, SkillMetada
     }
   }
   return map;
+}
+
+/**
+ * Filter skills that can be invoked by the model (appear in tool description).
+ * Excludes skills with disable-model-invocation: true in frontmatter.
+ */
+export function getModelInvocableSkills(skills: SkillMetadata[]): SkillMetadata[] {
+  return skills.filter((skill) => !skill.disableModelInvocation);
+}
+
+/**
+ * Filter skills that can be invoked by the user (appear in prompts menu).
+ * Excludes skills with user-invocable: false in frontmatter.
+ */
+export function getUserInvocableSkills(skills: SkillMetadata[]): SkillMetadata[] {
+  return skills.filter((skill) => skill.userInvocable !== false);
 }

--- a/src/skill-tool.ts
+++ b/src/skill-tool.ts
@@ -13,7 +13,7 @@ import * as path from "node:path";
 import { McpServer, RegisteredTool } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { CallToolResult } from "@modelcontextprotocol/sdk/types.js";
 import { z } from "zod";
-import { SkillMetadata, loadSkillContent, generateInstructions } from "./skill-discovery.js";
+import { SkillMetadata, loadSkillContent, generateInstructions, getModelInvocableSkills } from "./skill-discovery.js";
 
 /**
  * Shared state for dynamic skill management.
@@ -53,8 +53,9 @@ export function getToolDescription(skillState: SkillState): string {
     "actually calling this tool. This is a BLOCKING REQUIREMENT: invoke this tool BEFORE " +
     "generating any other response about the task.\n\n";
 
-  const skills = Array.from(skillState.skillMap.values());
-  return usage + generateInstructions(skills);
+  const allSkills = Array.from(skillState.skillMap.values());
+  const modelInvocableSkills = getModelInvocableSkills(allSkills);
+  return usage + generateInstructions(modelInvocableSkills);
 }
 
 export function registerSkillTool(


### PR DESCRIPTION
## Summary

- Adds support for `disable-model-invocation: true` frontmatter field to hide skills from tool description (user-only skills)
- Adds support for `user-invocable: false` frontmatter field to hide skills from prompts menu (model-only skills)
- Updates README with documentation for the new visibility control options

## Changes

| File | Changes |
|------|---------|
| `src/skill-discovery.ts` | Extended `SkillMetadata` interface, updated parsing, added filter functions |
| `src/skill-tool.ts` | Filter skills in tool description using `getModelInvocableSkills()` |
| `src/skill-prompts.ts` | Filter skills in prompts using `getUserInvocableSkills()` |
| `README.md` | Added "Skill Visibility Control" section |

## Test plan

- [x] Build passes (`npm run build`)
- [x] Skills with `disable-model-invocation: true` excluded from tool description
- [x] Skills with `user-invocable: false` excluded from prompts
- [x] Normal skills (no new frontmatter) appear in both tools and prompts
- [x] Resources remain unfiltered (all skills accessible via `skill://` URIs)

Closes #7

🤖 Generated with [Claude Code](https://claude.ai/code)