### PR TITLE
Add UI for human-friendly display of available skills

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,6 +21,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.1.42",
         "@types/node": "^22.10.0",
+        "cross-env": "^7.0.3",
         "tsx": "^4.19.2",
         "typescript": "^5.7.2",
         "vite": "^6.0.0",
@@ -1580,6 +1581,25 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/cross-env": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.3.tgz",
+      "integrity": "sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cross-spawn": "^7.0.1"
+      },
+      "bin": {
+        "cross-env": "src/bin/cross-env.js",
+        "cross-env-shell": "src/bin/cross-env-shell.js"
+      },
+      "engines": {
+        "node": ">=10.14",
+        "npm": ">=6",
+        "yarn": ">=1"
       }
     },
     "node_modules/cross-spawn": {

--- a/package.json
+++ b/package.json
@@ -36,8 +36,9 @@
     "node": ">=18.0.0"
   },
   "scripts": {
-    "build": "npm run build:ui && tsc",
+    "build": "npm run build:ui && npm run build:ui:display && tsc",
     "build:ui": "vite build",
+    "build:ui:display": "cross-env INPUT=skill-display.html vite build --emptyOutDir false",
     "start": "node dist/index.js",
     "dev": "tsx watch src/index.ts",
     "inspector": "npx @modelcontextprotocol/inspector@latest node dist/index.js",
@@ -60,6 +61,7 @@
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.1.42",
     "@types/node": "^22.10.0",
+    "cross-env": "^7.0.3",
     "tsx": "^4.19.2",
     "typescript": "^5.7.2",
     "vite": "^6.0.0",

--- a/src/skill-display-tool.ts
+++ b/src/skill-display-tool.ts
@@ -1,0 +1,369 @@
+/**
+ * MCP App tool registration for skill display UI.
+ *
+ * Registers:
+ * - skill-display: Opens the skill display UI
+ * - skill-display-update-invocation: Updates invocation settings (UI-only)
+ * - skill-display-reset-override: Resets a skill to frontmatter defaults (UI-only)
+ */
+
+import * as fs from "node:fs";
+import * as fsPromises from "node:fs/promises";
+import * as path from "node:path";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { CallToolResult, ReadResourceResult } from "@modelcontextprotocol/sdk/types.js";
+import {
+  registerAppTool,
+  registerAppResource,
+  RESOURCE_MIME_TYPE,
+} from "@modelcontextprotocol/ext-apps/server";
+import { z } from "zod";
+import {
+  getSkillInvocationOverrides,
+  setSkillInvocationOverride,
+  clearSkillInvocationOverride,
+} from "./skill-config.js";
+import { SkillState } from "./skill-tool.js";
+
+/**
+ * Resource URI for the skill-display UI.
+ */
+const RESOURCE_URI = "ui://skill-display/skill-display.html";
+
+/**
+ * Get the path to the bundled UI HTML file.
+ */
+function getUIPath(): string {
+  const possiblePaths = [
+    // From dist/skill-display-tool.js
+    path.join(import.meta.dirname, "ui", "skill-display.html"),
+    // From src/ during development
+    path.join(import.meta.dirname, "..", "dist", "ui", "skill-display.html"),
+  ];
+
+  for (const p of possiblePaths) {
+    if (fs.existsSync(p)) {
+      return p;
+    }
+  }
+
+  throw new Error(
+    `UI file not found. Tried: ${possiblePaths.join(", ")}. ` +
+      "Run 'npm run build:ui:display' to build the UI."
+  );
+}
+
+/**
+ * Schema shape for update-invocation tool input.
+ */
+const UpdateInvocationInputSchema = {
+  skillName: z.string().describe("Name of the skill to update"),
+  setting: z.enum(["assistant", "user"]).describe("Which setting to update"),
+  value: z.boolean().describe("New value for the setting"),
+};
+
+/**
+ * Schema shape for reset-override tool input.
+ */
+const ResetOverrideInputSchema = {
+  skillName: z.string().describe("Name of the skill to reset"),
+  setting: z.enum(["assistant", "user"]).optional().describe("Which setting to reset (omit for both)"),
+};
+
+/**
+ * Callback type for when invocation settings change.
+ */
+export type OnInvocationChangedCallback = () => void;
+
+/**
+ * Skill info structure for UI display.
+ */
+interface SkillDisplayInfo {
+  name: string;
+  description: string;
+  path: string;
+  assistantInvocable: boolean;
+  userInvocable: boolean;
+  isAssistantOverridden: boolean;
+  isUserOverridden: boolean;
+}
+
+/**
+ * Get skill display info from skill state.
+ */
+function getSkillDisplayInfo(skillState: SkillState): SkillDisplayInfo[] {
+  const skills: SkillDisplayInfo[] = [];
+  for (const skill of skillState.skillMap.values()) {
+    skills.push({
+      name: skill.name,
+      description: skill.description,
+      path: skill.path,
+      assistantInvocable: skill.effectiveAssistantInvocable,
+      userInvocable: skill.effectiveUserInvocable,
+      isAssistantOverridden: skill.isAssistantOverridden,
+      isUserOverridden: skill.isUserOverridden,
+    });
+  }
+  // Sort by name for consistent display
+  skills.sort((a, b) => a.name.localeCompare(b.name));
+  return skills;
+}
+
+/**
+ * Register skill-display MCP App tools and resource.
+ *
+ * @param server - The MCP server instance
+ * @param skillState - Shared skill state for getting skill info
+ * @param onInvocationChanged - Callback when invocation settings are changed
+ */
+export function registerSkillDisplayTool(
+  server: McpServer,
+  skillState: SkillState,
+  onInvocationChanged: OnInvocationChangedCallback
+): void {
+  // Main display tool - opens UI
+  registerAppTool(
+    server,
+    "skill-display",
+    {
+      title: "View Skills",
+      description:
+        "Open the skill display UI to view available skills and configure their invocation settings. " +
+        "Use when user wants to see skills or toggle assistant/user invocation.",
+      inputSchema: {},
+      outputSchema: {
+        skills: z.array(z.object({
+          name: z.string(),
+          description: z.string(),
+          path: z.string(),
+          assistantInvocable: z.boolean(),
+          userInvocable: z.boolean(),
+          isAssistantOverridden: z.boolean(),
+          isUserOverridden: z.boolean(),
+        })),
+        totalCount: z.number(),
+      },
+      _meta: { ui: { resourceUri: RESOURCE_URI } },
+      annotations: {
+        readOnlyHint: true,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (): Promise<CallToolResult> => {
+      const skills = getSkillDisplayInfo(skillState);
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: `Skill display UI opened. ${skills.length} skill(s) available.`,
+          },
+        ],
+        structuredContent: {
+          skills,
+          totalCount: skills.length,
+        },
+      };
+    }
+  );
+
+  // Update invocation tool (UI-only, hidden from model)
+  registerAppTool(
+    server,
+    "skill-display-update-invocation",
+    {
+      title: "Update Skill Invocation",
+      description: "Update invocation settings for a skill.",
+      inputSchema: UpdateInvocationInputSchema,
+      outputSchema: {
+        success: z.boolean(),
+        skills: z.array(z.object({
+          name: z.string(),
+          description: z.string(),
+          path: z.string(),
+          assistantInvocable: z.boolean(),
+          userInvocable: z.boolean(),
+          isAssistantOverridden: z.boolean(),
+          isUserOverridden: z.boolean(),
+        })).optional(),
+        totalCount: z.number().optional(),
+        error: z.string().optional(),
+      },
+      _meta: {
+        ui: {
+          resourceUri: RESOURCE_URI,
+          visibility: ["app"], // Hidden from model, UI can call it
+        },
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: false,
+        openWorldHint: false,
+      },
+    },
+    async (args): Promise<CallToolResult> => {
+      const { skillName, setting, value } = args as {
+        skillName: string;
+        setting: "assistant" | "user";
+        value: boolean;
+      };
+
+      try {
+        // Verify skill exists
+        if (!skillState.skillMap.has(skillName)) {
+          throw new Error(`Skill not found: ${skillName}`);
+        }
+
+        // Update the override
+        setSkillInvocationOverride(skillName, setting, value);
+
+        // Trigger refresh to apply the new override
+        onInvocationChanged();
+
+        // Return updated skill list
+        const skills = getSkillDisplayInfo(skillState);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Updated ${skillName}: ${setting} = ${value}`,
+            },
+          ],
+          structuredContent: {
+            success: true,
+            skills,
+            totalCount: skills.length,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to update invocation: ${message}`,
+            },
+          ],
+          structuredContent: {
+            success: false,
+            error: message,
+          },
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Reset override tool (UI-only, hidden from model)
+  registerAppTool(
+    server,
+    "skill-display-reset-override",
+    {
+      title: "Reset Skill Override",
+      description: "Reset a skill's invocation settings to frontmatter defaults.",
+      inputSchema: ResetOverrideInputSchema,
+      outputSchema: {
+        success: z.boolean(),
+        skills: z.array(z.object({
+          name: z.string(),
+          description: z.string(),
+          path: z.string(),
+          assistantInvocable: z.boolean(),
+          userInvocable: z.boolean(),
+          isAssistantOverridden: z.boolean(),
+          isUserOverridden: z.boolean(),
+        })).optional(),
+        totalCount: z.number().optional(),
+        error: z.string().optional(),
+      },
+      _meta: {
+        ui: {
+          resourceUri: RESOURCE_URI,
+          visibility: ["app"], // Hidden from model, UI can call it
+        },
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args): Promise<CallToolResult> => {
+      const { skillName, setting } = args as {
+        skillName: string;
+        setting?: "assistant" | "user";
+      };
+
+      try {
+        // Verify skill exists
+        if (!skillState.skillMap.has(skillName)) {
+          throw new Error(`Skill not found: ${skillName}`);
+        }
+
+        // Clear the override
+        clearSkillInvocationOverride(skillName, setting);
+
+        // Trigger refresh to apply the change
+        onInvocationChanged();
+
+        // Return updated skill list
+        const skills = getSkillDisplayInfo(skillState);
+        const settingText = setting ? setting : "all settings";
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Reset ${skillName} (${settingText}) to frontmatter default`,
+            },
+          ],
+          structuredContent: {
+            success: true,
+            skills,
+            totalCount: skills.length,
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [
+            {
+              type: "text",
+              text: `Failed to reset override: ${message}`,
+            },
+          ],
+          structuredContent: {
+            success: false,
+            error: message,
+          },
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Register the HTML UI resource
+  registerAppResource(
+    server,
+    RESOURCE_URI,
+    RESOURCE_URI,
+    { mimeType: RESOURCE_MIME_TYPE },
+    async (): Promise<ReadResourceResult> => {
+      const uiPath = getUIPath();
+      const html = await fsPromises.readFile(uiPath, "utf-8");
+
+      return {
+        contents: [
+          {
+            uri: RESOURCE_URI,
+            mimeType: RESOURCE_MIME_TYPE,
+            text: html,
+          },
+        ],
+      };
+    }
+  );
+}

--- a/src/ui/skill-display.css
+++ b/src/ui/skill-display.css
@@ -1,0 +1,282 @@
+:root {
+  --bg: #1a1a2e;
+  --bg-secondary: #16213e;
+  --bg-tertiary: #0f1729;
+  --text: #e8e8e8;
+  --text-secondary: #a0a0a0;
+  --accent: #6366f1;
+  --accent-hover: #818cf8;
+  --border: #2a2a4a;
+  --success: #22c55e;
+  --warning: #eab308;
+  --error: #ef4444;
+  --info: #3b82f6;
+}
+
+@media (prefers-color-scheme: light) {
+  :root {
+    --bg: #ffffff;
+    --bg-secondary: #f5f5f5;
+    --bg-tertiary: #e8e8e8;
+    --text: #1a1a1a;
+    --text-secondary: #666666;
+    --border: #e0e0e0;
+  }
+}
+
+* {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+  background: var(--bg);
+  color: var(--text);
+  padding: 16px;
+  min-height: 100vh;
+}
+
+.header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 16px;
+  padding-bottom: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+h1 {
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.stats {
+  font-size: 12px;
+  color: var(--text-secondary);
+  margin-top: 4px;
+}
+
+/* Search bar */
+.search-bar {
+  margin-bottom: 16px;
+}
+
+.search-bar input {
+  width: 100%;
+  padding: 10px 14px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text);
+  font-size: 14px;
+}
+
+.search-bar input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.search-bar input::placeholder {
+  color: var(--text-secondary);
+}
+
+/* Skill list */
+.skill-list {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+/* Skill card */
+.skill-card {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+}
+
+.skill-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  margin-bottom: 8px;
+}
+
+.skill-name {
+  font-size: 15px;
+  font-weight: 600;
+}
+
+.customized-badge {
+  font-size: 10px;
+  padding: 2px 8px;
+  background: var(--warning);
+  color: #000;
+  border-radius: 4px;
+  text-transform: uppercase;
+  font-weight: 600;
+}
+
+.skill-description {
+  font-size: 13px;
+  color: var(--text-secondary);
+  margin-bottom: 10px;
+  line-height: 1.4;
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.skill-path {
+  font-family: 'Fira Code', 'Consolas', monospace;
+  font-size: 11px;
+  color: var(--text-secondary);
+  margin-bottom: 12px;
+  word-break: break-all;
+  opacity: 0.7;
+}
+
+/* Toggle controls */
+.skill-controls {
+  display: flex;
+  gap: 16px;
+  padding-top: 10px;
+  border-top: 1px solid var(--border);
+}
+
+.toggle-group {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.toggle-label {
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.toggle-label.overridden {
+  color: var(--warning);
+}
+
+/* Toggle switch */
+.toggle-switch {
+  position: relative;
+  width: 40px;
+  height: 22px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 11px;
+  cursor: pointer;
+  transition: background 0.2s, border-color 0.2s;
+}
+
+.toggle-switch.active {
+  background: var(--success);
+  border-color: var(--success);
+}
+
+.toggle-switch::after {
+  content: '';
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  background: var(--text);
+  border-radius: 50%;
+  transition: transform 0.2s;
+}
+
+.toggle-switch.active::after {
+  transform: translateX(18px);
+  background: white;
+}
+
+.toggle-switch:hover {
+  border-color: var(--accent);
+}
+
+/* Reset button */
+.reset-btn {
+  font-size: 11px;
+  padding: 4px 10px;
+  background: transparent;
+  color: var(--text-secondary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  cursor: pointer;
+  margin-left: auto;
+}
+
+.reset-btn:hover {
+  background: var(--border);
+  color: var(--text);
+}
+
+.reset-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+/* Empty state */
+.empty-state {
+  text-align: center;
+  padding: 40px 20px;
+  color: var(--text-secondary);
+}
+
+.empty-state p {
+  margin-bottom: 12px;
+}
+
+/* Loading state */
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: var(--text-secondary);
+}
+
+/* Toast */
+.toast {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+  padding: 12px 18px;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  font-size: 13px;
+  z-index: 200;
+  display: none;
+  max-width: 300px;
+}
+
+.toast.success {
+  border-color: var(--success);
+  color: var(--success);
+}
+
+.toast.error {
+  border-color: var(--error);
+  color: var(--error);
+}
+
+.toast.visible {
+  display: block;
+  animation: slideIn 0.3s ease;
+}
+
+@keyframes slideIn {
+  from {
+    transform: translateX(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0);
+    opacity: 1;
+  }
+}

--- a/src/ui/skill-display.html
+++ b/src/ui/skill-display.html
@@ -1,0 +1,35 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="color-scheme" content="light dark">
+  <title>Available Skills</title>
+  <link rel="stylesheet" href="./skill-display.css">
+</head>
+<body>
+  <div class="header">
+    <div>
+      <h1>Available Skills</h1>
+      <div class="stats" id="stats">Loading...</div>
+    </div>
+  </div>
+
+  <div class="search-bar">
+    <input
+      type="text"
+      id="search-input"
+      placeholder="Search skills..."
+    >
+  </div>
+
+  <div id="skill-list" class="skill-list">
+    <div class="loading">Loading skills...</div>
+  </div>
+
+  <!-- Toast -->
+  <div class="toast" id="toast"></div>
+
+  <script type="module" src="./skill-display.ts"></script>
+</body>
+</html>

--- a/src/ui/skill-display.ts
+++ b/src/ui/skill-display.ts
@@ -1,0 +1,297 @@
+/**
+ * Skill Display MCP App - Vanilla JS implementation
+ */
+import {
+  App,
+  applyDocumentTheme,
+  applyHostStyleVariables,
+  applyHostFonts,
+} from "@modelcontextprotocol/ext-apps";
+
+// Types
+interface SkillDisplayInfo {
+  name: string;
+  description: string;
+  path: string;
+  assistantInvocable: boolean;
+  userInvocable: boolean;
+  isAssistantOverridden: boolean;
+  isUserOverridden: boolean;
+}
+
+interface SkillDisplayState {
+  skills: SkillDisplayInfo[];
+  totalCount: number;
+  success?: boolean;
+  error?: string;
+}
+
+// State
+let skills: SkillDisplayInfo[] = [];
+let searchQuery = "";
+let app: App | null = null;
+
+// DOM Elements
+const skillList = document.getElementById("skill-list")!;
+const stats = document.getElementById("stats")!;
+const searchInput = document.getElementById("search-input") as HTMLInputElement;
+const toast = document.getElementById("toast")!;
+
+// Handle host context changes
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function handleHostContextChanged(ctx: any) {
+  if (ctx.theme) {
+    applyDocumentTheme(ctx.theme);
+  }
+  if (ctx.styles?.variables) {
+    applyHostStyleVariables(ctx.styles.variables);
+  }
+  if (ctx.styles?.css?.fonts) {
+    applyHostFonts(ctx.styles.css.fonts);
+  }
+  // Handle safe area insets for mobile/notched devices
+  if (ctx.safeAreaInsets) {
+    const { top, right, bottom, left } = ctx.safeAreaInsets;
+    document.body.style.paddingTop = `${top + 16}px`;
+    document.body.style.paddingRight = `${right + 16}px`;
+    document.body.style.paddingBottom = `${bottom + 16}px`;
+    document.body.style.paddingLeft = `${left + 16}px`;
+  }
+}
+
+// Update state from tool result
+function updateState(data: SkillDisplayState) {
+  if (data.skills) {
+    skills = data.skills;
+  }
+  render();
+}
+
+// Get filtered skills based on search query
+function getFilteredSkills(): SkillDisplayInfo[] {
+  if (!searchQuery) {
+    return skills;
+  }
+  const query = searchQuery.toLowerCase();
+  return skills.filter(
+    (skill) =>
+      skill.name.toLowerCase().includes(query) ||
+      skill.description.toLowerCase().includes(query)
+  );
+}
+
+// Render the UI
+function render() {
+  renderStats();
+  renderSkills();
+}
+
+function renderStats() {
+  const filtered = getFilteredSkills();
+  if (searchQuery) {
+    stats.textContent = `${filtered.length} of ${skills.length} skills`;
+  } else {
+    stats.textContent = `${skills.length} skill${skills.length !== 1 ? "s" : ""} available`;
+  }
+}
+
+function renderSkills() {
+  const filtered = getFilteredSkills();
+
+  if (skills.length === 0) {
+    skillList.innerHTML = `
+      <div class="empty-state">
+        <p>No skills available.</p>
+        <p>Configure skill directories using the skill-config tool.</p>
+      </div>
+    `;
+    return;
+  }
+
+  if (filtered.length === 0) {
+    skillList.innerHTML = `
+      <div class="empty-state">
+        <p>No skills match your search.</p>
+      </div>
+    `;
+    return;
+  }
+
+  skillList.innerHTML = filtered
+    .map((skill) => {
+      const isCustomized = skill.isAssistantOverridden || skill.isUserOverridden;
+      return `
+      <div class="skill-card" data-skill="${escapeHtml(skill.name)}">
+        <div class="skill-header">
+          <span class="skill-name">${escapeHtml(skill.name)}</span>
+          ${isCustomized ? '<span class="customized-badge">Customized</span>' : ""}
+        </div>
+        <p class="skill-description">${escapeHtml(skill.description)}</p>
+        <div class="skill-path">${escapeHtml(skill.path)}</div>
+        <div class="skill-controls">
+          <div class="toggle-group">
+            <span class="toggle-label ${skill.isAssistantOverridden ? "overridden" : ""}">Assistant</span>
+            <div
+              class="toggle-switch ${skill.assistantInvocable ? "active" : ""}"
+              data-skill="${escapeHtml(skill.name)}"
+              data-setting="assistant"
+              data-value="${skill.assistantInvocable}"
+              title="${skill.assistantInvocable ? "Model can auto-invoke this skill" : "Model cannot auto-invoke this skill"}"
+            ></div>
+          </div>
+          <div class="toggle-group">
+            <span class="toggle-label ${skill.isUserOverridden ? "overridden" : ""}">User</span>
+            <div
+              class="toggle-switch ${skill.userInvocable ? "active" : ""}"
+              data-skill="${escapeHtml(skill.name)}"
+              data-setting="user"
+              data-value="${skill.userInvocable}"
+              title="${skill.userInvocable ? "Appears in prompts menu" : "Hidden from prompts menu"}"
+            ></div>
+          </div>
+          <button
+            class="reset-btn"
+            data-skill="${escapeHtml(skill.name)}"
+            ${!isCustomized ? "disabled" : ""}
+            title="Reset to frontmatter defaults"
+          >Reset</button>
+        </div>
+      </div>
+    `;
+    })
+    .join("");
+
+  // Add click handlers for toggle switches
+  skillList.querySelectorAll(".toggle-switch").forEach((toggle) => {
+    toggle.addEventListener("click", () => {
+      const skillName = (toggle as HTMLElement).dataset.skill;
+      const setting = (toggle as HTMLElement).dataset.setting as "assistant" | "user";
+      const currentValue = (toggle as HTMLElement).dataset.value === "true";
+      if (skillName && setting) {
+        updateInvocation(skillName, setting, !currentValue);
+      }
+    });
+  });
+
+  // Add click handlers for reset buttons
+  skillList.querySelectorAll(".reset-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const skillName = (btn as HTMLButtonElement).dataset.skill;
+      if (skillName) {
+        resetOverride(skillName);
+      }
+    });
+  });
+}
+
+// Update invocation setting
+async function updateInvocation(
+  skillName: string,
+  setting: "assistant" | "user",
+  value: boolean
+) {
+  try {
+    const result = await app!.callServerTool({
+      name: "skill-display-update-invocation",
+      arguments: { skillName, setting, value },
+    });
+
+    console.log("Update result:", result);
+
+    const structured = result.structuredContent as unknown as SkillDisplayState;
+    if (structured?.success) {
+      updateState(structured);
+      showToast(`${skillName}: ${setting} = ${value ? "on" : "off"}`, "success");
+    } else {
+      showToast(structured?.error || "Failed to update", "error");
+    }
+  } catch (error) {
+    console.error("Update invocation error:", error);
+    showToast((error as Error).message || "Failed to update", "error");
+  }
+}
+
+// Reset override
+async function resetOverride(skillName: string) {
+  try {
+    const result = await app!.callServerTool({
+      name: "skill-display-reset-override",
+      arguments: { skillName },
+    });
+
+    console.log("Reset result:", result);
+
+    const structured = result.structuredContent as unknown as SkillDisplayState;
+    if (structured?.success) {
+      updateState(structured);
+      showToast(`${skillName} reset to defaults`, "success");
+    } else {
+      showToast(structured?.error || "Failed to reset", "error");
+    }
+  } catch (error) {
+    console.error("Reset override error:", error);
+    showToast((error as Error).message || "Failed to reset", "error");
+  }
+}
+
+// Toast
+function showToast(message: string, type: "success" | "error" = "success") {
+  toast.textContent = message;
+  toast.className = `toast ${type} visible`;
+  setTimeout(() => {
+    toast.classList.remove("visible");
+  }, 3000);
+}
+
+// Utilities
+function escapeHtml(str: string): string {
+  if (!str) return "";
+  return String(str).replace(/[&<>"']/g, (c) =>
+    ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" })[c] || c
+  );
+}
+
+// Set up event listeners
+searchInput.addEventListener("input", () => {
+  searchQuery = searchInput.value.trim();
+  render();
+});
+
+// 1. Create app instance
+app = new App({ name: "Skill Display", version: "1.0.0" });
+
+// 2. Register handlers BEFORE connecting
+app.onteardown = async () => {
+  console.info("App is being torn down");
+  return {};
+};
+
+app.ontoolinput = (params) => {
+  console.info("Received tool input:", params);
+};
+
+app.ontoolresult = (result) => {
+  console.info("Received tool result:", result);
+  if (result.structuredContent) {
+    updateState(result.structuredContent as SkillDisplayState);
+  }
+};
+
+app.ontoolcancelled = (params) => {
+  console.info("Tool call cancelled:", params.reason);
+};
+
+app.onerror = console.error;
+
+app.onhostcontextchanged = handleHostContextChanged;
+
+// 3. Connect to host
+app.connect().then(() => {
+  console.info("Connected to host");
+
+  // Apply initial host context
+  const ctx = app!.getHostContext();
+  if (ctx) {
+    handleHostContextChanged(ctx);
+  }
+});


### PR DESCRIPTION
## Summary
- Add new MCP App UI (`skill-display` tool) for viewing and configuring skill invocation settings
- Display all available skills with name, description, and path
- Toggle "Assistant" (model auto-invocation) and "User" (prompts menu visibility) per skill
- Settings stored in `~/.skilljack/config.json` as overrides to YAML frontmatter defaults
- Search/filter functionality for skill discovery

## Test plan
- [ ] Run `npm run build` - verify no errors
- [ ] Start server with `node dist/index.js`
- [ ] Open MCP Inspector and verify `skill-display` tool appears
- [ ] Call `skill-display` tool - verify UI opens with skill list
- [ ] Toggle a skill's "Assistant" setting - verify config file updates
- [ ] Restart server - verify override persists
- [ ] Click "Reset" - verify skill reverts to frontmatter default

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)