### PR TITLE
Translate frontmatter metadata to _meta on MCP primitives

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -36,6 +36,7 @@ src/
 
 **SkillMetadata** - Parsed skill info:
 - `name`, `description`, `path` (to SKILL.md)
+- `metadata` (optional) - From frontmatter `metadata` key, translated to `_meta` on MCP resources/tool results
 
 **RegisteredTool** - SDK type for dynamic tool updates:
 - Returned by `registerSkillTool()`

--- a/skills/skilljack-docs/SKILL.md
+++ b/skills/skilljack-docs/SKILL.md
@@ -366,6 +366,7 @@ Control which skills appear in tools vs prompts using optional frontmatter field
 | (default) | Yes | Yes | Normal skills |
 | `disable-model-invocation: true` | No | Yes | User-triggered workflows (deploy, commit) |
 | `user-invocable: false` | Yes | No | Background context (model auto-loads when relevant) |
+| `metadata: { key: value }` | — | — | Arbitrary key-value pairs passed as `_meta` on MCP primitives |
 
 ### Example: User-Only Skill
 
@@ -391,7 +392,23 @@ user-invocable: false
 ---
 ```
 
-Note: Resources (`skill://` URIs) always include all skills regardless of these settings, allowing explicit access when needed.
+### Skill Metadata
+
+The optional `metadata` frontmatter field allows attaching arbitrary key-value pairs to a skill, following the [Agent Skills spec](https://agentskills.io/specification). Values are coerced to strings. The metadata is translated to `_meta` on MCP resources and tool results.
+
+```yaml
+---
+name: my-skill
+description: A helpful skill
+metadata:
+  author: example-org
+  version: "1.0"
+---
+```
+
+When this skill's resources are listed or its content is loaded via the `skill` or `skill-resource` tools, the response includes `_meta: { author: "example-org", version: "1.0" }`.
+
+Note: Resources (`skill://` URIs) always include all skills regardless of visibility settings, allowing explicit access when needed.
 
 ## Testing
 

--- a/src/skill-resources.ts
+++ b/src/skill-resources.ts
@@ -85,15 +85,19 @@ function registerSkillDirectoryCollection(
     new ResourceTemplate("skill://{skillName}/", {
       list: async () => {
         // Return one entry per skill (the directory collection)
-        const resources: Array<{ uri: string; name: string; mimeType: string; description?: string }> = [];
+        const resources: Array<{ uri: string; name: string; mimeType: string; description?: string; _meta?: Record<string, string> }> = [];
 
         for (const [name, skill] of skillState.skillMap) {
-          resources.push({
+          const resource: (typeof resources)[number] = {
             uri: `skill://${encodeURIComponent(name)}/`,
             name: `${name}/`,
             mimeType: "text/plain",
             description: `All files in ${name} skill directory`,
-          });
+          };
+          if (skill.metadata) {
+            resource._meta = skill.metadata;
+          }
+          resources.push(resource);
         }
 
         return { resources };
@@ -184,15 +188,19 @@ function registerSkillTemplate(
     new ResourceTemplate("skill://{skillName}", {
       list: async () => {
         // Dynamically return current skills
-        const resources: Array<{ uri: string; name: string; mimeType: string; description?: string }> = [];
+        const resources: Array<{ uri: string; name: string; mimeType: string; description?: string; _meta?: Record<string, string> }> = [];
 
         for (const [name, skill] of skillState.skillMap) {
-          resources.push({
+          const resource: (typeof resources)[number] = {
             uri: `skill://${encodeURIComponent(name)}`,
             name,
             mimeType: "text/markdown",
             description: skill.description,
-          });
+          };
+          if (skill.metadata) {
+            resource._meta = skill.metadata;
+          }
+          resources.push(resource);
         }
 
         return { resources };

--- a/src/skill-tool.ts
+++ b/src/skill-tool.ts
@@ -94,7 +94,7 @@ export function registerSkillTool(
 
       try {
         const content = loadSkillContent(skill.path);
-        return {
+        const result: CallToolResult = {
           content: [
             {
               type: "text",
@@ -102,6 +102,10 @@ export function registerSkillTool(
             },
           ],
         };
+        if (skill.metadata) {
+          result._meta = skill.metadata;
+        }
+        return result;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {
@@ -363,7 +367,11 @@ function registerSkillResourceTool(
           }
         }
 
-        return { content: contents };
+        const dirResult: CallToolResult = { content: contents };
+        if (skill.metadata) {
+          dirResult._meta = skill.metadata;
+        }
+        return dirResult;
       }
 
       // Check file size to prevent memory exhaustion
@@ -397,7 +405,7 @@ function registerSkillResourceTool(
       // Read and return the file content
       try {
         const content = fs.readFileSync(fullPath, "utf-8");
-        return {
+        const fileResult: CallToolResult = {
           content: [
             {
               type: "text",
@@ -405,6 +413,10 @@ function registerSkillResourceTool(
             },
           ],
         };
+        if (skill.metadata) {
+          fileResult._meta = skill.metadata;
+        }
+        return fileResult;
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
         return {


### PR DESCRIPTION
## Summary

- Parses the `metadata` field from SKILL.md YAML frontmatter (per the [Agent Skills spec](https://agentskills.io/specification)) and translates it to `_meta` on MCP resources and tool call results
- Values are coerced to strings per the spec (`dict[str, str]`)
- Invalid `metadata` types (arrays, scalars) log a warning and are skipped
- Documents the new field in the bundled docs skill and CLAUDE.md

### Where `_meta` flows

| MCP Primitive | `_meta` included |
|---|---|
| `resources/list` (skill templates) | Yes |
| `resources/list` (directory collections) | Yes |
| `tools/call` result (`skill` tool) | Yes |
| `tools/call` result (`skill-resource` tool) | Yes |
| Per-skill prompts | Deferred (SDK `registerPrompt` doesn't support `_meta` yet) |

### Example

```yaml
---
name: my-skill
description: A helpful skill
metadata:
  author: example-org
  version: "1.0"
---
```

Produces `_meta: { author: "example-org", version: "1.0" }` on resources and tool results.

## Test plan

- [ ] Create a test skill with `metadata` in frontmatter, verify `resources/list` returns `_meta`
- [ ] Verify `tools/call` with `skill` tool returns `_meta` in result
- [ ] Verify `tools/call` with `skill-resource` tool returns `_meta` in result
- [ ] Verify skills without `metadata` have no `_meta` on resources/results
- [ ] Verify invalid `metadata` types (string, array, null) log warnings and are excluded
- [ ] `npm run build` passes cleanly

Closes #32

🤖 Generated with [Claude Code](https://claude.com/claude-code)