### PR TITLE
Add warning when large number of skills are loaded

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -26,7 +26,7 @@ import chokidar from "chokidar";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { discoverSkills, createSkillMap, applyInvocationOverrides, SkillSource, DEFAULT_SKILL_SOURCE, BUNDLED_SKILL_SOURCE } from "./skill-discovery.js";
+import { discoverSkills, createSkillMap, applyInvocationOverrides, SkillSource, DEFAULT_SKILL_SOURCE, BUNDLED_SKILL_SOURCE, warnLargeSkillCount } from "./skill-discovery.js";
 import { registerSkillTool, getToolDescription, SkillState } from "./skill-tool.js";
 import { registerSkillResources } from "./skill-resources.js";
 import { registerSkillPrompts, refreshPrompts, PromptRegistry } from "./skill-prompts.js";
@@ -316,6 +316,7 @@ function refreshSkills(
   skillState.skillMap = createSkillMap(skills);
 
   console.error(`Skills refreshed: ${oldCount} -> ${skills.length} skill(s)`);
+  warnLargeSkillCount(skills.length);
 
   // Update the skill tool description with new instructions
   skillTool.update({
@@ -542,6 +543,7 @@ async function main() {
 
   skillState.skillMap = createSkillMap(skills);
   console.error(`Discovered ${skills.length} skill(s)`);
+  warnLargeSkillCount(skills.length);
 
   // Create the MCP server
   // In static mode, disable listChanged for tools/prompts (skills list is frozen)

--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -330,3 +330,15 @@ export function getModelInvocableSkills(skills: SkillMetadata[]): SkillMetadata[
 export function getUserInvocableSkills(skills: SkillMetadata[]): SkillMetadata[] {
   return skills.filter((skill) => skill.effectiveUserInvocable);
 }
+
+export const SKILL_COUNT_WARNING_THRESHOLD = 50;
+
+export function warnLargeSkillCount(skillCount: number): void {
+  if (skillCount >= SKILL_COUNT_WARNING_THRESHOLD) {
+    console.error(
+      `Warning: ${skillCount} skills discovered. Large skill counts can degrade LLM performance ` +
+      `by bloating tool descriptions. Consider reducing the number of skill directories or ` +
+      `setting 'disable-model-invocation: true' in SKILL.md frontmatter for user-only skills.`
+    );
+  }
+}

--- a/src/ui/mcp-app.css
+++ b/src/ui/mcp-app.css
@@ -123,6 +123,21 @@ h1 {
   font-weight: 600;
 }
 
+/* Warning banner */
+.warning-banner {
+  background: color-mix(in srgb, var(--warning) 15%, var(--bg-secondary));
+  border: 1px solid var(--warning);
+  padding: 10px 14px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--warning);
+}
+
+.warning-banner strong {
+  color: var(--warning);
+}
+
 /* Directory list */
 .directory-list {
   display: flex;

--- a/src/ui/mcp-app.html
+++ b/src/ui/mcp-app.html
@@ -27,6 +27,10 @@
     Changes to the config file won't take effect while this override is active.
   </div>
 
+  <div class="warning-banner" id="skill-count-warning" style="display: none;">
+    <strong>Warning:</strong> Large number of skills detected. This may degrade LLM performance by bloating tool descriptions. Consider removing skill directories.
+  </div>
+
   <div id="directory-list" class="directory-list">
     <div class="loading">Loading directories...</div>
   </div>

--- a/src/ui/mcp-app.ts
+++ b/src/ui/mcp-app.ts
@@ -140,6 +140,13 @@ function renderStats() {
   if (validCount < directories.length) {
     stats.textContent += ` (${directories.length - validCount} missing)`;
   }
+
+  const warningBanner = document.getElementById("skill-count-warning")!;
+  if (totalSkills >= 50) {
+    warningBanner.style.display = "block";
+  } else {
+    warningBanner.style.display = "none";
+  }
 }
 
 function renderOverrideBanner() {

--- a/src/ui/skill-display.css
+++ b/src/ui/skill-display.css
@@ -82,6 +82,21 @@ h1 {
   color: var(--accent);
 }
 
+/* Warning banner */
+.warning-banner {
+  background: color-mix(in srgb, var(--warning) 15%, var(--bg-secondary));
+  border: 1px solid var(--warning);
+  padding: 10px 14px;
+  border-radius: 6px;
+  margin-bottom: 16px;
+  font-size: 12px;
+  color: var(--warning);
+}
+
+.warning-banner strong {
+  color: var(--warning);
+}
+
 /* Search bar */
 .search-bar {
   margin-bottom: 16px;

--- a/src/ui/skill-display.html
+++ b/src/ui/skill-display.html
@@ -19,6 +19,10 @@
     <strong>Tip:</strong> Ask Claude to "configure skills" to manage skill directories and GitHub sources.
   </div>
 
+  <div class="warning-banner" id="skill-count-warning" style="display: none;">
+    <strong>Warning:</strong> Large number of skills detected. This may degrade LLM performance by bloating tool descriptions. Consider disabling unused skills.
+  </div>
+
   <div class="search-bar">
     <input
       type="text"

--- a/src/ui/skill-display.ts
+++ b/src/ui/skill-display.ts
@@ -98,6 +98,13 @@ function renderStats() {
   } else {
     stats.textContent = `${skills.length} skill${skills.length !== 1 ? "s" : ""} available`;
   }
+
+  const warningBanner = document.getElementById("skill-count-warning")!;
+  if (skills.length >= 50) {
+    warningBanner.style.display = "block";
+  } else {
+    warningBanner.style.display = "none";
+  }
 }
 
 function renderSkills() {


### PR DESCRIPTION
## Summary

- Adds a warning when 50+ skills are discovered, alerting users that large skill counts can degrade LLM performance by bloating tool descriptions
- Warning appears in three places: stderr logs (at startup and refresh), the skill-display UI, and the skill-config UI
- Suggests remediation: reduce skill directories or set `disable-model-invocation: true` in SKILL.md frontmatter

Closes #31

## Test plan

- [ ] Run with < 50 skills — verify no warning in stderr or UIs
- [ ] Run with >= 50 skills (or temporarily lower `SKILL_COUNT_WARNING_THRESHOLD`) — verify warning appears in stderr at startup
- [ ] Add/remove skills dynamically — verify warning appears/disappears on refresh
- [ ] Open skill-display UI — verify yellow warning banner shows when >= 50 skills
- [ ] Open skill-config UI — verify yellow warning banner shows when total >= 50 skills

🤖 Generated with [Claude Code](https://claude.com/claude-code)