### PR TITLE
Validate _meta keys against MCP spec naming rules

### DIFF
--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -110,6 +110,67 @@ export function sanitizePrefix(raw: string): string {
 }
 
 /**
+ * Regex patterns for MCP _meta key validation.
+ * See: https://modelcontextprotocol.io/specification/2025-11-25/basic/index#_meta
+ */
+const LABEL_PATTERN = /^[a-zA-Z](?:[a-zA-Z0-9-]*[a-zA-Z0-9])?$/;
+const NAME_PATTERN = /^[a-zA-Z0-9](?:[a-zA-Z0-9._-]*[a-zA-Z0-9])?$/;
+
+/**
+ * Validate a metadata key against MCP spec _meta key naming rules.
+ *
+ * Valid keys have two segments: an optional prefix and a name.
+ * - Prefix: labels separated by dots, followed by `/`. Labels start with a letter,
+ *   end with letter/digit, interior can be letters/digits/hyphens.
+ *   Implementations SHOULD use reverse DNS notation (e.g., `com.example/`).
+ * - Name: starts/ends with alphanumeric, interior can be alphanumerics/hyphens/underscores/dots.
+ *   May be empty if prefix is present.
+ * - Reserved: prefixes where the second label is `modelcontextprotocol` or `mcp`
+ *   (e.g., `io.modelcontextprotocol/`, `dev.mcp/`). Note: `com.example.mcp/` is NOT reserved.
+ */
+export function validateMetaKey(key: string): { valid: boolean; reserved?: boolean; reason?: string } {
+  if (!key) {
+    return { valid: false, reason: "key is empty" };
+  }
+
+  const slashIndex = key.indexOf("/");
+  let name: string;
+
+  if (slashIndex !== -1) {
+    const prefix = key.substring(0, slashIndex);
+    name = key.substring(slashIndex + 1);
+
+    // Validate prefix labels
+    const labels = prefix.split(".");
+    for (const label of labels) {
+      if (!label || !LABEL_PATTERN.test(label)) {
+        return { valid: false, reason: `invalid prefix label "${label}"` };
+      }
+    }
+
+    // Check reserved prefixes: second label is "modelcontextprotocol" or "mcp" (per 2025-11-25 spec)
+    if (labels.length >= 2) {
+      const secondLabel = labels[1].toLowerCase();
+      if (secondLabel === "modelcontextprotocol" || secondLabel === "mcp") {
+        return { valid: true, reserved: true, reason: `prefix "${prefix}/" is reserved for MCP protocol use` };
+      }
+    }
+  } else {
+    name = key;
+  }
+
+  // Validate name (empty name is valid per spec when prefix is present)
+  if (name && !NAME_PATTERN.test(name)) {
+    return {
+      valid: false,
+      reason: `must start/end with alphanumeric, contain only alphanumerics/hyphens/underscores/dots`,
+    };
+  }
+
+  return { valid: true };
+}
+
+/**
  * Compute the qualified name for a skill by combining prefix and base name.
  * If prefix is empty, returns the base name unchanged.
  */
@@ -164,13 +225,30 @@ export function discoverSkills(skillsDir: string, source?: SkillSource): SkillMe
       }
 
       // Validate metadata: must be a plain object if provided (Agent Skills spec: string keys to string values)
+      // Keys are validated against MCP _meta naming rules; invalid/reserved keys are warned and skipped.
       let skillMetadata: Record<string, string> | undefined;
       if (rawMetadata !== undefined && rawMetadata !== null) {
         if (typeof rawMetadata === "object" && !Array.isArray(rawMetadata)) {
-          // Coerce all values to strings per Agent Skills spec
-          skillMetadata = Object.fromEntries(
-            Object.entries(rawMetadata as Record<string, unknown>).map(([k, v]) => [String(k), String(v)])
-          );
+          const validEntries: [string, string][] = [];
+          for (const [k, v] of Object.entries(rawMetadata as Record<string, unknown>)) {
+            const keyStr = String(k);
+            const validation = validateMetaKey(keyStr);
+            if (!validation.valid) {
+              console.error(`Skill at ${skillDir}: skipping metadata key "${keyStr}": ${validation.reason}`);
+              continue;
+            }
+            if (validation.reserved) {
+              console.error(
+                `Warning: Skill at ${skillDir}: skipping metadata key "${keyStr}": ${validation.reason}`
+              );
+              continue;
+            }
+            // Coerce values to strings per Agent Skills spec
+            validEntries.push([keyStr, String(v)]);
+          }
+          if (validEntries.length > 0) {
+            skillMetadata = Object.fromEntries(validEntries);
+          }
         } else {
           console.error(
             `Skill at ${skillDir}: 'metadata' must be a YAML mapping (key-value pairs), got ${Array.isArray(rawMetadata) ? "array" : typeof rawMetadata}`


### PR DESCRIPTION
## Summary

- Add `validateMetaKey()` function that checks metadata keys against the [MCP spec's `_meta` key naming rules](https://modelcontextprotocol.io/specification/2025-11-25/basic/index#_meta)
- Validate prefix labels (must start with letter, end with letter/digit, interior letters/digits/hyphens)
- Validate name segment (must start/end with alphanumeric, interior alphanumerics/hyphens/underscores/dots)
- Detect and skip keys using reserved prefixes (second label is `modelcontextprotocol` or `mcp`, per 2025-11-25 spec)
- Invalid and reserved keys are warned on stderr and excluded from `_meta`

## Test plan

- [ ] Build succeeds (`npm run build`)
- [ ] Valid metadata keys (e.g., `version`, `author`, `com.example/custom-key`) pass through to `_meta`
- [ ] Invalid keys (e.g., `-starts-with-dash`, `has spaces`, `!special`) are skipped with warning
- [ ] Reserved-prefix keys (e.g., `dev.mcp/something`, `io.modelcontextprotocol/task`) are skipped with warning
- [ ] Non-reserved keys with `mcp` in other label positions (e.g., `com.example.mcp/foo`) are allowed
- [ ] Skills with no metadata are unaffected
- [ ] Skills where all metadata keys are invalid result in `metadata: undefined`

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)