### PR TITLE
Add audience annotations to skill:// resources (#43)

### DIFF
--- a/src/skill-discovery.test.ts
+++ b/src/skill-discovery.test.ts
@@ -441,4 +441,24 @@ describe("getResourceAnnotations", () => {
     const result = getResourceAnnotations(skill, Infinity);
     expect(result.priority).toBe(0.5);
   });
+
+  it("falls back to 0.5 for -Infinity priority", () => {
+    const skill = createTestSkill();
+    const result = getResourceAnnotations(skill, -Infinity);
+    expect(result.priority).toBe(0.5);
+  });
+
+  it("includes lastModified for existing file paths", () => {
+    // Use this test file itself as a real path
+    const skill = createTestSkill({ path: __filename });
+    const result = getResourceAnnotations(skill);
+    expect(result.lastModified).toBeDefined();
+    expect(new Date(result.lastModified!).getTime()).not.toBeNaN();
+  });
+
+  it("omits lastModified when file path does not exist", () => {
+    const skill = createTestSkill({ path: "/fake/path/SKILL.md" });
+    const result = getResourceAnnotations(skill);
+    expect(result.lastModified).toBeUndefined();
+  });
 });

--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -432,7 +432,14 @@ export function getResourceAnnotations(
   if (skill.effectiveUserInvocable) {
     audience.push("user");
   }
-  return { audience, priority: clampedPriority };
+  const annotations: Annotations = { audience, priority: clampedPriority };
+  try {
+    const stat = fs.statSync(skill.path);
+    annotations.lastModified = stat.mtime.toISOString();
+  } catch {
+    // Skip lastModified if file cannot be stat'd
+  }
+  return annotations;
 }
 
 export const SKILL_COUNT_WARNING_THRESHOLD = 50;

--- a/src/skill-resources.ts
+++ b/src/skill-resources.ts
@@ -19,7 +19,7 @@
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { Resource } from "@modelcontextprotocol/sdk/types.js";
+import type { Resource } from "@modelcontextprotocol/sdk/types.js";
 import { loadSkillContent, getResourceAnnotations } from "./skill-discovery.js";
 import { isPathWithinBase, listSkillFiles, MAX_FILE_SIZE, SkillState } from "./skill-tool.js";
 


### PR DESCRIPTION
## Summary

- Added `annotations` with `audience` and `priority` to `skill://` resources returned by `resources/list`, enabling client-side filtering and context management
- `audience` is derived from existing effective invocation flags (`effectiveAssistantInvocable` / `effectiveUserInvocable`), so frontmatter `disable-model-invocation` and `user-invocable` flags automatically flow through
- Resource listing priority defaults to `0.5` (discovery), distinct from the existing `1.0` used in prompt-activated contexts

## Details

New `getResourceAnnotations()` helper in `skill-discovery.ts` centralizes the audience derivation logic:

| `effectiveAssistantInvocable` | `effectiveUserInvocable` | `audience` |
|---|---|---|
| true | true | `["assistant", "user"]` |
| true | false | `["assistant"]` |
| false | true | `["user"]` |
| false | false | `[]` |

Extracted a `SkillResource` type alias in `skill-resources.ts` to replace repeated inline types across both resource templates.

Read handlers (`resources/read`) are unchanged — per the MCP spec, `ResourceContents` does not carry `annotations`.

Closes #43

## Test plan

- [ ] `npm run build` passes
- [ ] MCP Inspector: `resources/list` returns `annotations` with correct `audience` and `priority` for default skills
- [ ] MCP Inspector: skill with `user-invocable: false` → `audience: ["assistant"]`
- [ ] MCP Inspector: skill with `disable-model-invocation: true` → `audience: ["user"]`
- [ ] MCP Inspector: `resources/read` does NOT include annotations (spec compliance)
- [ ] Config overrides update annotations after refresh

🤖 Generated with [Claude Code](https://claude.com/claude-code)