### PR TITLE
Align resource layer with SEP-2640 (Skills Extension)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -25,7 +25,7 @@ src/
 ├── skill-discovery.ts # YAML frontmatter parsing, XML generation
 ├── skill-tool.ts      # MCP tools: skill, skill-resource
 ├── skill-prompts.ts   # MCP Prompts: /skill with auto-completion, per-skill prompts
-├── skill-resources.ts # MCP Resources: skill:// URI scheme
+├── skill-resources.ts # MCP Resources: SEP-2640 skill:// URI scheme + skill://index.json
 └── subscriptions.ts   # File watching, resource subscriptions
 ```
 
@@ -67,6 +67,10 @@ src/
 | `refreshSkills()` | index.ts | Re-discover + update tool/prompts + notify clients |
 | `watchSkillDirectories()` | index.ts | Set up chokidar watchers (skipped in static mode) |
 | `sanitizePrefix()` | skill-discovery.ts | Clean prefix strings for qualified names |
+| `getSkillPath()` | skill-discovery.ts | Compute SEP-2640 `<skill-path>` (`<prefix>/<baseName>` or just `<baseName>`) |
+| `buildSkillResourceUri()` | skill-discovery.ts | Build a `skill://<skill-path>/<file>` URI |
+| `parseSkillResourceUri()` | skill-discovery.ts | Resolve a `skill://` URI back to a skill + file relpath |
+| `buildSkillIndex()` | skill-discovery.ts | Build the JSON document served at `skill://index.json` |
 | `generateInstructions()` | skill-discovery.ts | Create XML skill list |
 | `getToolDescription()` | skill-tool.ts | Usage text + skill list for tool desc |
 | `registerSkillPrompts()` | skill-prompts.ts | Register /skill + per-skill prompts |
@@ -91,18 +95,33 @@ src/
 capabilities: {
   tools: { listChanged: !isStatic },      // Dynamic tool updates (disabled in static mode)
   resources: { subscribe: true, listChanged: true },
-  prompts: { listChanged: !isStatic }     // Dynamic prompt updates (disabled in static mode)
+  prompts: { listChanged: !isStatic },    // Dynamic prompt updates (disabled in static mode)
+  extensions: {
+    "io.modelcontextprotocol/skills": {}, // SEP-2640 Skills Extension
+  },
 }
 ```
 
 In static mode (`--static` or `SKILLJACK_STATIC=true`), `tools.listChanged` and `prompts.listChanged` are set to `false`. Resource subscriptions remain fully dynamic.
+
+## Resource URIs (SEP-2640)
+
+The resource layer follows [SEP-2640 (Skills Extension)](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640):
+
+| URI | Returns |
+|-----|---------|
+| `skill://<skill-path>/SKILL.md` | The skill's SKILL.md (`text/markdown`). Listed. |
+| `skill://<skill-path>/<file-path>` | A supporting file inside the skill directory. Not listed; template-resolvable. |
+| `skill://index.json` | SEP-2640 discovery index (`application/json`). Listed. |
+
+`<skill-path>` is `<prefix>/<baseName>` for prefixed skills (local: dir basename, GitHub: `owner-repo`) or just `<baseName>` for bundled. The final URI segment always equals the frontmatter `name` per SEP. Build/parse via `buildSkillResourceUri()` / `parseSkillResourceUri()` in `skill-discovery.ts`.
 
 ## Notifications Sent
 
 - `notifications/tools/list_changed` - When skills change (add/modify/remove)
 - `notifications/prompts/list_changed` - When skills change (add/modify/remove)
 - `notifications/resources/list_changed` - When skills change
-- `notifications/resources/updated` - When subscribed resource files change
+- `notifications/resources/updated` - When subscribed resource files change. Also fired explicitly for `skill://index.json` from `refreshSkills()` so subscribers see add/remove changes even without an underlying SKILL.md modification.
 
 ## Conventions
 

--- a/skills/skilljack-docs/SKILL.md
+++ b/skills/skilljack-docs/SKILL.md
@@ -15,7 +15,7 @@ An MCP server that jacks [Agent Skills](https://agentskills.io) directly into yo
 - **Tool List Changed Notifications** - Sends `tools/listChanged` so clients can refresh available skills
 - **Skill Tool** - Load full skill content on demand (progressive disclosure)
 - **MCP Prompts** - Load skills via `/skill` prompt with auto-completion or per-skill prompts
-- **MCP Resources** - Access skills via `skill://` URIs with batch collection support
+- **MCP Resources** - Access skills via `skill://` URIs aligned with [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640)
 - **Resource Subscriptions** - Real-time file watching with `notifications/resources/updated`
 - **Configuration UI** - Manage skill directories through an interactive UI in supported clients
 
@@ -264,16 +264,17 @@ Prompts return embedded resources with the skill's `skill://` URI, allowing clie
 
 ## Resources
 
-Skills are also accessible via MCP [Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resources) using `skill://` URIs.
+Skills are also accessible via MCP [Resources](https://modelcontextprotocol.io/specification/2025-11-25/server/resources#resources) using `skill://` URIs, following the [SEP-2640 Skills Extension](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) convention. The server advertises support via the `extensions["io.modelcontextprotocol/skills"]` capability key in its `initialize` response.
 
 ### URI Patterns
 
 | URI | Returns |
 |-----|---------|
-| `skill://{name}` | Single skill's SKILL.md content |
-| `skill://{name}/` | All files in skill directory (collection) |
+| `skill://<skill-path>/SKILL.md` | The skill's `SKILL.md` (`text/markdown`). Listed in `resources/list`. |
+| `skill://<skill-path>/<file-path>` | A supporting file inside the skill directory. Template-resolvable; not listed. |
+| `skill://index.json` | SEP-2640 discovery index (`application/json`). Listed in `resources/list`. |
 
-Individual file URIs (`skill://{name}/{path}`) are not listed as resources to reduce noise. Use the `skill-resource` tool to fetch specific files on demand.
+`<skill-path>` is `<prefix>/<baseName>` for prefixed skills (the prefix segments come from the skill's source — e.g., a local directory basename or `owner-repo` for GitHub-sourced skills) or just `<baseName>` for bundled skills. The final `<skill-path>` segment always matches the `name` field in the skill's frontmatter, per SEP.
 
 ### Resource Subscriptions
 
@@ -283,20 +284,22 @@ Clients can subscribe to resources for real-time updates when files change.
 
 **Subscribe to a resource:**
 ```
-→ resources/subscribe { uri: "skill://mcp-server-ts" }
+→ resources/subscribe { uri: "skill://skilljack-docs/SKILL.md" }
 ← {} (success)
 ```
 
 **Receive notifications when files change:**
 ```
-← notifications/resources/updated { uri: "skill://mcp-server-ts" }
+← notifications/resources/updated { uri: "skill://skilljack-docs/SKILL.md" }
 ```
 
 **Unsubscribe:**
 ```
-→ resources/unsubscribe { uri: "skill://mcp-server-ts" }
+→ resources/unsubscribe { uri: "skill://skilljack-docs/SKILL.md" }
 ← {} (success)
 ```
+
+Subscribing to `skill://index.json` watches every SKILL.md, so any skill change re-fires that subscription as well as `notifications/resources/updated` for `skill://index.json` directly when skills are added or removed.
 
 **How it works:**
 1. Client subscribes to a `skill://` URI

--- a/src/index.ts
+++ b/src/index.ts
@@ -340,6 +340,15 @@ function refreshSkills(
 
   // Also notify that resources have changed
   server.sendResourceListChanged();
+
+  // The SEP-2640 index resource always changes when the skill list changes,
+  // even when no individual SKILL.md was modified (e.g., a skill was added
+  // or removed). Emit an explicit update notification so subscribed clients
+  // refetch.
+  server.server.notification({
+    method: "notifications/resources/updated",
+    params: { uri: "skill://index.json" },
+  });
 }
 
 /**
@@ -558,6 +567,10 @@ async function main() {
         tools: { listChanged: !isStatic },
         resources: { subscribe: true, listChanged: true },
         prompts: { listChanged: !isStatic },
+        // SEP-2640 (Skills Extension): https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640
+        extensions: {
+          "io.modelcontextprotocol/skills": {},
+        },
       },
     }
   );

--- a/src/skill-discovery.test.ts
+++ b/src/skill-discovery.test.ts
@@ -10,6 +10,11 @@ import {
   warnLargeSkillCount,
   discoverSkills,
   getResourceAnnotations,
+  getSkillPath,
+  buildSkillResourceUri,
+  parseSkillResourceUri,
+  buildSkillIndex,
+  BUNDLED_SKILL_SOURCE,
   SKILL_COUNT_WARNING_THRESHOLD,
 } from "./skill-discovery.js";
 import { createTestSkill, createTestSource } from "./__test-helpers__/helpers.js";
@@ -361,5 +366,199 @@ describe("getResourceAnnotations", () => {
     const { annotations, size } = getResourceAnnotations(skill);
     expect(annotations.lastModified).toBeUndefined();
     expect(size).toBeUndefined();
+  });
+});
+
+describe("getSkillPath (SEP-2640)", () => {
+  it("returns baseName alone for bundled skills (empty prefix)", () => {
+    const skill = createTestSkill({
+      baseName: "git-workflow",
+      source: BUNDLED_SKILL_SOURCE,
+    });
+    expect(getSkillPath(skill)).toBe("git-workflow");
+  });
+
+  it("returns prefix/baseName for prefixed skills", () => {
+    const skill = createTestSkill({
+      baseName: "commit",
+      source: createTestSource({ prefix: "my-project" }),
+    });
+    expect(getSkillPath(skill)).toBe("my-project/commit");
+  });
+
+  it("sanitizes the prefix", () => {
+    const skill = createTestSkill({
+      baseName: "deploy",
+      source: createTestSource({ prefix: "Hello World!" }),
+    });
+    expect(getSkillPath(skill)).toBe("Hello-World/deploy");
+  });
+
+  it("falls back to baseName when sanitized prefix is empty", () => {
+    const skill = createTestSkill({
+      baseName: "lone",
+      source: createTestSource({ prefix: "@#$" }),
+    });
+    expect(getSkillPath(skill)).toBe("lone");
+  });
+});
+
+describe("buildSkillResourceUri (SEP-2640)", () => {
+  it("builds skill://baseName/SKILL.md for bundled skills", () => {
+    const skill = createTestSkill({
+      baseName: "git-workflow",
+      source: BUNDLED_SKILL_SOURCE,
+    });
+    expect(buildSkillResourceUri(skill, "SKILL.md")).toBe(
+      "skill://git-workflow/SKILL.md"
+    );
+  });
+
+  it("builds skill://prefix/baseName/SKILL.md for prefixed skills", () => {
+    const skill = createTestSkill({
+      baseName: "refunds",
+      source: createTestSource({ prefix: "acme-billing" }),
+    });
+    expect(buildSkillResourceUri(skill, "SKILL.md")).toBe(
+      "skill://acme-billing/refunds/SKILL.md"
+    );
+  });
+
+  it("preserves slashes between file path segments while encoding each segment", () => {
+    const skill = createTestSkill({
+      baseName: "pdf-processing",
+      source: BUNDLED_SKILL_SOURCE,
+    });
+    expect(buildSkillResourceUri(skill, "scripts/extract.py")).toBe(
+      "skill://pdf-processing/scripts/extract.py"
+    );
+  });
+
+  it("percent-encodes spaces and special chars within a file segment", () => {
+    const skill = createTestSkill({
+      baseName: "docs",
+      source: BUNDLED_SKILL_SOURCE,
+    });
+    expect(buildSkillResourceUri(skill, "templates/email subject.md")).toBe(
+      "skill://docs/templates/email%20subject.md"
+    );
+  });
+});
+
+describe("parseSkillResourceUri (SEP-2640)", () => {
+  const bundled = createTestSkill({
+    baseName: "my-skill",
+    name: "my-skill",
+    path: "/skills/my-skill/SKILL.md",
+    source: BUNDLED_SKILL_SOURCE,
+  });
+  const prefixed = createTestSkill({
+    baseName: "refunds",
+    name: "acme-billing__refunds",
+    path: "/skills/refunds/SKILL.md",
+    source: createTestSource({ prefix: "acme-billing" }),
+  });
+  const map = new Map([
+    [bundled.name, bundled],
+    [prefixed.name, prefixed],
+  ]);
+
+  it("resolves bundled SKILL.md URI", () => {
+    const result = parseSkillResourceUri("skill://my-skill/SKILL.md", map);
+    expect(result?.skill).toBe(bundled);
+    expect(result?.fileRelPath).toBe("SKILL.md");
+  });
+
+  it("resolves prefixed SKILL.md URI", () => {
+    const result = parseSkillResourceUri(
+      "skill://acme-billing/refunds/SKILL.md",
+      map
+    );
+    expect(result?.skill).toBe(prefixed);
+    expect(result?.fileRelPath).toBe("SKILL.md");
+  });
+
+  it("resolves a nested supporting-file URI", () => {
+    const result = parseSkillResourceUri(
+      "skill://acme-billing/refunds/templates/email.md",
+      map
+    );
+    expect(result?.skill).toBe(prefixed);
+    expect(result?.fileRelPath).toBe("templates/email.md");
+  });
+
+  it("returns null for non-skill scheme", () => {
+    expect(parseSkillResourceUri("http://example.com/x", map)).toBeNull();
+  });
+
+  it("returns null when no skill matches", () => {
+    expect(parseSkillResourceUri("skill://nope/SKILL.md", map)).toBeNull();
+  });
+
+  it("returns null for a legacy bare skill://name URI (no file)", () => {
+    expect(parseSkillResourceUri("skill://my-skill", map)).toBeNull();
+  });
+
+  it("returns null for a legacy skill://name/ URI (empty file segment)", () => {
+    expect(parseSkillResourceUri("skill://my-skill/", map)).toBeNull();
+  });
+});
+
+describe("buildSkillIndex (SEP-2640)", () => {
+  it("emits the SEP $schema URL", () => {
+    const map = new Map([
+      ["a", createTestSkill({ name: "a", baseName: "a", source: BUNDLED_SKILL_SOURCE })],
+    ]);
+    expect(buildSkillIndex(map).$schema).toBe(
+      "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+    );
+  });
+
+  it("emits one entry per skill with type skill-md and the SKILL.md URL", () => {
+    const a = createTestSkill({
+      name: "a",
+      baseName: "a",
+      description: "skill A",
+      source: BUNDLED_SKILL_SOURCE,
+    });
+    const b = createTestSkill({
+      name: "p__b",
+      baseName: "b",
+      description: "skill B",
+      source: createTestSource({ prefix: "p" }),
+    });
+    const index = buildSkillIndex(
+      new Map([
+        [a.name, a],
+        [b.name, b],
+      ])
+    );
+    expect(index.skills).toHaveLength(2);
+    expect(index.skills).toEqual(
+      expect.arrayContaining([
+        {
+          name: "a",
+          type: "skill-md",
+          description: "skill A",
+          url: "skill://a/SKILL.md",
+        },
+        {
+          name: "b",
+          type: "skill-md",
+          description: "skill B",
+          url: "skill://p/b/SKILL.md",
+        },
+      ])
+    );
+  });
+
+  it("uses baseName, not the qualified name, for the index name field", () => {
+    const skill = createTestSkill({
+      name: "my-project__commit",
+      baseName: "commit",
+      source: createTestSource({ prefix: "my-project" }),
+    });
+    const index = buildSkillIndex(new Map([[skill.name, skill]]));
+    expect(index.skills[0].name).toBe("commit");
   });
 });

--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -120,6 +120,87 @@ function qualifyName(prefix: string, baseName: string): string {
 }
 
 /**
+ * Compute the SEP-2640 <skill-path> for a skill.
+ *
+ * Bundled (empty prefix) → baseName
+ * Other → "<sanitizePrefix(prefix)>/<baseName>"
+ *
+ * The final segment always equals the frontmatter `name`, per SEP.
+ */
+export function getSkillPath(skill: SkillMetadata): string {
+  const prefix = sanitizePrefix(skill.source.prefix);
+  return prefix ? `${prefix}/${skill.baseName}` : skill.baseName;
+}
+
+/**
+ * Build a full skill resource URI for a file relative to the skill root.
+ * Per-segment encoding preserves slashes between path segments.
+ */
+export function buildSkillResourceUri(skill: SkillMetadata, fileRelPath: string): string {
+  const skillPath = getSkillPath(skill);
+  const encodedFile = fileRelPath.split("/").map(encodeURIComponent).join("/");
+  return `skill://${skillPath}/${encodedFile}`;
+}
+
+/**
+ * Parse a skill:// URI into a (skill, fileRelPath) pair.
+ *
+ * Walks skillMap to disambiguate <skill-path> from <file-path>, since the URI
+ * itself does not encode where the skill segment ends. Longest-path-first
+ * matching handles overlapping prefixes (e.g., foo/bar vs foo/bar/baz).
+ *
+ * Returns null if the URI is not a skill:// URI or no skill matches.
+ */
+export function parseSkillResourceUri(
+  uri: string,
+  skillMap: Map<string, SkillMetadata>
+): { skill: SkillMetadata; fileRelPath: string } | null {
+  const m = uri.match(/^skill:\/\/(.+)$/);
+  if (!m) return null;
+  // Decode per-segment so segments containing literal %2F round-trip cleanly.
+  const remainder = m[1].split("/").map(decodeURIComponent).join("/");
+  const candidates = Array.from(skillMap.values())
+    .map((s) => ({ s, p: getSkillPath(s) }))
+    .sort((a, b) => b.p.length - a.p.length);
+  for (const { s, p } of candidates) {
+    if (remainder.startsWith(p + "/")) {
+      const fileRelPath = remainder.slice(p.length + 1);
+      // Reject URIs with no file segment (e.g., legacy "skill://name/").
+      // SEP-2640 requires SKILL.md to be explicit in the URI.
+      if (fileRelPath === "") return null;
+      return { skill: s, fileRelPath };
+    }
+  }
+  return null;
+}
+
+/**
+ * Build the SEP-2640 discovery index document.
+ *
+ * All skills are emitted as type "skill-md" with a URL pointing to their
+ * SKILL.md resource. Archive and resource-template entry types are out of
+ * scope for this server.
+ */
+export function buildSkillIndex(skillMap: Map<string, SkillMetadata>): {
+  $schema: string;
+  skills: Array<{ name: string; type: "skill-md"; description: string; url: string }>;
+} {
+  const skills: Array<{ name: string; type: "skill-md"; description: string; url: string }> = [];
+  for (const skill of skillMap.values()) {
+    skills.push({
+      name: skill.baseName,
+      type: "skill-md",
+      description: skill.description,
+      url: buildSkillResourceUri(skill, "SKILL.md"),
+    });
+  }
+  return {
+    $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+    skills,
+  };
+}
+
+/**
  * Discover all skills in a directory.
  * Scans for subdirectories containing SKILL.md files.
  *

--- a/src/skill-prompts.ts
+++ b/src/skill-prompts.ts
@@ -9,7 +9,12 @@
 import { McpServer, RegisteredPrompt } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { completable } from "@modelcontextprotocol/sdk/server/completable.js";
 import { z } from "zod";
-import { loadSkillContent, generateInstructions, getUserInvocableSkills } from "./skill-discovery.js";
+import {
+  loadSkillContent,
+  generateInstructions,
+  getUserInvocableSkills,
+  buildSkillResourceUri,
+} from "./skill-discovery.js";
 import { SkillState } from "./skill-tool.js";
 
 /**
@@ -99,7 +104,7 @@ export function registerSkillPrompts(
               content: {
                 type: "resource",
                 resource: {
-                  uri: `skill://${name}`,
+                  uri: buildSkillResourceUri(skill, "SKILL.md"),
                   mimeType: "text/markdown",
                   text: content,
                 },
@@ -183,6 +188,7 @@ export function registerSkillPrompts(
     // Capture skill info in closure for this specific prompt
     const skillPath = skill.path;
     const skillName = name;
+    const skillUri = buildSkillResourceUri(skill, "SKILL.md");
     const prompt = server.registerPrompt(
       name,
       {
@@ -200,7 +206,7 @@ export function registerSkillPrompts(
                 content: {
                   type: "resource" as const,
                   resource: {
-                    uri: `skill://${skillName}`,
+                    uri: skillUri,
                     mimeType: "text/markdown",
                     text: content,
                   },
@@ -289,6 +295,7 @@ export function refreshPrompts(
       // Register new skill prompt with embedded resource
       const skillPath = skill.path;
       const skillName = name;
+      const skillUri = buildSkillResourceUri(skill, "SKILL.md");
       const prompt = server.registerPrompt(
         name,
         {
@@ -305,7 +312,7 @@ export function refreshPrompts(
                   content: {
                     type: "resource" as const,
                     resource: {
-                      uri: `skill://${skillName}`,
+                      uri: skillUri,
                       mimeType: "text/markdown",
                       text: content,
                     },

--- a/src/skill-resources.test.ts
+++ b/src/skill-resources.test.ts
@@ -5,14 +5,15 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
 import { registerSkillResources } from "./skill-resources.js";
-import { createTestSkill, createTestSkillState } from "./__test-helpers__/helpers.js";
+import { BUNDLED_SKILL_SOURCE } from "./skill-discovery.js";
+import {
+  createTestSkill,
+  createTestSkillState,
+  createTestSource,
+} from "./__test-helpers__/helpers.js";
 
 const FIXTURES_DIR = path.resolve(__dirname, "__fixtures__", "skills");
 
-/**
- * Helper: wire up a McpServer + Client over InMemoryTransport,
- * register skill resources, and return the connected client.
- */
 async function createConnectedClient(
   skills: ReturnType<typeof createTestSkill>[]
 ) {
@@ -29,62 +30,82 @@ async function createConnectedClient(
   return client;
 }
 
-describe("skill resources: size field", () => {
-  it("includes size on skill template resources for real files", async () => {
+describe("SKILL.md resource (SEP-2640)", () => {
+  it("lists one SKILL.md resource per skill at the SEP URI shape", async () => {
     const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
     const expectedSize = fs.statSync(skillPath).size;
 
     const client = await createConnectedClient([
-      createTestSkill({ name: "valid", path: skillPath }),
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
     ]);
 
     const result = await client.listResources();
     const skillResource = result.resources.find(
-      (r) => r.uri === "skill://valid"
+      (r) => r.uri === "skill://test-skill/SKILL.md"
     );
 
     expect(skillResource).toBeDefined();
+    expect(skillResource!.mimeType).toBe("text/markdown");
+    expect(skillResource!.name).toBe("test-skill");
     expect(skillResource!.size).toBe(expectedSize);
   });
 
-  it("includes size on skill directory collection resources for real files", async () => {
-    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
-    const expectedSize = fs.statSync(skillPath).size;
-
-    const client = await createConnectedClient([
-      createTestSkill({ name: "valid", path: skillPath }),
-    ]);
-
-    const result = await client.listResources();
-    const dirResource = result.resources.find(
-      (r) => r.uri === "skill://valid/"
-    );
-
-    expect(dirResource).toBeDefined();
-    expect(dirResource!.size).toBe(expectedSize);
-  });
-
-  it("omits size when skill path does not exist", async () => {
-    const client = await createConnectedClient([
-      createTestSkill({ name: "missing", path: "/fake/path/SKILL.md" }),
-    ]);
-
-    const result = await client.listResources();
-    const skillResource = result.resources.find(
-      (r) => r.uri === "skill://missing"
-    );
-
-    expect(skillResource).toBeDefined();
-    expect(skillResource!.size).toBeUndefined();
-  });
-
-  it("includes annotations alongside size", async () => {
+  it("uses prefix as URI path segment for non-bundled skills", async () => {
     const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
 
     const client = await createConnectedClient([
       createTestSkill({
-        name: "annotated",
+        name: "my-project__test-skill",
+        baseName: "test-skill",
         path: skillPath,
+        source: createTestSource({ prefix: "my-project" }),
+      }),
+    ]);
+
+    const result = await client.listResources();
+    const skillResource = result.resources.find(
+      (r) => r.uri === "skill://my-project/test-skill/SKILL.md"
+    );
+
+    expect(skillResource).toBeDefined();
+  });
+
+  it("returns SKILL.md content via resources/read", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+    const expectedContent = fs.readFileSync(skillPath, "utf-8");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.readResource({
+      uri: "skill://test-skill/SKILL.md",
+    });
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].mimeType).toBe("text/markdown");
+    expect(result.contents[0].text).toBe(expectedContent);
+  });
+
+  it("includes audience annotations and priority 0.8", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
         effectiveAssistantInvocable: true,
         effectiveUserInvocable: false,
       }),
@@ -92,45 +113,217 @@ describe("skill resources: size field", () => {
 
     const result = await client.listResources();
     const resource = result.resources.find(
-      (r) => r.uri === "skill://annotated"
-    );
-
-    expect(resource).toBeDefined();
-    expect(resource!.size).toBeGreaterThan(0);
-    expect(resource!.annotations?.audience).toEqual(["assistant"]);
-  });
-});
-
-describe("skill resources: priority differentiation", () => {
-  it("sets priority 0.8 on primary skill resources", async () => {
-    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
-
-    const client = await createConnectedClient([
-      createTestSkill({ name: "test", path: skillPath }),
-    ]);
-
-    const result = await client.listResources();
-    const resource = result.resources.find(
-      (r) => r.uri === "skill://test"
+      (r) => r.uri === "skill://test-skill/SKILL.md"
     );
 
     expect(resource).toBeDefined();
     expect(resource!.annotations?.priority).toBe(0.8);
+    expect(resource!.annotations?.audience).toEqual(["assistant"]);
   });
 
-  it("sets priority 0.3 on directory collection resources", async () => {
-    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
-
+  it("omits size when SKILL.md path does not exist", async () => {
     const client = await createConnectedClient([
-      createTestSkill({ name: "test", path: skillPath }),
+      createTestSkill({
+        name: "missing",
+        baseName: "missing",
+        path: "/fake/path/SKILL.md",
+        source: BUNDLED_SKILL_SOURCE,
+      }),
     ]);
 
     const result = await client.listResources();
     const resource = result.resources.find(
-      (r) => r.uri === "skill://test/"
+      (r) => r.uri === "skill://missing/SKILL.md"
     );
 
     expect(resource).toBeDefined();
-    expect(resource!.annotations?.priority).toBe(0.3);
+    expect(resource!.size).toBeUndefined();
+  });
+
+  it("does not list bare skill:// or trailing-slash URIs (legacy shapes)", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.listResources();
+    const legacyBare = result.resources.find((r) => r.uri === "skill://test-skill");
+    const legacyDir = result.resources.find((r) => r.uri === "skill://test-skill/");
+    expect(legacyBare).toBeUndefined();
+    expect(legacyDir).toBeUndefined();
+  });
+});
+
+describe("supporting-file resource (SEP-2640)", () => {
+  it("does NOT list internal files in resources/list", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "with-resources", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "resourceful",
+        baseName: "resourceful",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.listResources();
+    const internal = result.resources.find((r) =>
+      r.uri.startsWith("skill://resourceful/scripts/")
+    );
+    expect(internal).toBeUndefined();
+  });
+
+  it("returns file content on resources/read at skill://<path>/<file>", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "with-resources", "SKILL.md");
+    const expectedScript = fs.readFileSync(
+      path.join(FIXTURES_DIR, "with-resources", "scripts", "example.py"),
+      "utf-8"
+    );
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "resourceful",
+        baseName: "resourceful",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.readResource({
+      uri: "skill://resourceful/scripts/example.py",
+    });
+
+    expect(result.contents).toHaveLength(1);
+    expect(result.contents[0].text).toBe(expectedScript);
+    expect(result.contents[0].mimeType).toBe("text/x-python");
+  });
+
+  it("rejects path traversal attempts", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "with-resources", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "resourceful",
+        baseName: "resourceful",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    await expect(
+      client.readResource({
+        uri: "skill://resourceful/..%2F..%2Fetc%2Fpasswd",
+      })
+    ).rejects.toThrow();
+  });
+
+  it("errors cleanly when file does not exist", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "with-resources", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "resourceful",
+        baseName: "resourceful",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    await expect(
+      client.readResource({ uri: "skill://resourceful/nope.txt" })
+    ).rejects.toThrow();
+  });
+});
+
+describe("skill://index.json (SEP-2640 discovery)", () => {
+  it("is listed exactly once in resources/list", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.listResources();
+    const indexes = result.resources.filter((r) => r.uri === "skill://index.json");
+    expect(indexes).toHaveLength(1);
+    expect(indexes[0].mimeType).toBe("application/json");
+  });
+
+  it("returns SEP-shaped JSON on resources/read", async () => {
+    const skillPath1 = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+    const skillPath2 = path.join(FIXTURES_DIR, "with-resources", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        description: "valid test skill",
+        path: skillPath1,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+      createTestSkill({
+        name: "resourceful",
+        baseName: "resourceful",
+        description: "skill with files",
+        path: skillPath2,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const result = await client.readResource({ uri: "skill://index.json" });
+    expect(result.contents).toHaveLength(1);
+    const body = JSON.parse(result.contents[0].text as string);
+
+    expect(body.$schema).toBe(
+      "https://schemas.agentskills.io/discovery/0.2.0/schema.json"
+    );
+    expect(body.skills).toHaveLength(2);
+
+    const test = body.skills.find((s: { name: string }) => s.name === "test-skill");
+    expect(test).toMatchObject({
+      name: "test-skill",
+      type: "skill-md",
+      description: "valid test skill",
+      url: "skill://test-skill/SKILL.md",
+    });
+
+    const resourceful = body.skills.find(
+      (s: { name: string }) => s.name === "resourceful"
+    );
+    expect(resourceful).toMatchObject({
+      name: "resourceful",
+      type: "skill-md",
+      description: "skill with files",
+      url: "skill://resourceful/SKILL.md",
+    });
+  });
+
+  it("uses prefixed URLs for non-bundled skills", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+
+    const client = await createConnectedClient([
+      createTestSkill({
+        name: "my-project__test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: createTestSource({ prefix: "my-project" }),
+      }),
+    ]);
+
+    const result = await client.readResource({ uri: "skill://index.json" });
+    const body = JSON.parse(result.contents[0].text as string);
+    expect(body.skills[0].url).toBe("skill://my-project/test-skill/SKILL.md");
   });
 });

--- a/src/skill-resources.ts
+++ b/src/skill-resources.ts
@@ -1,27 +1,30 @@
 /**
- * MCP Resource registration for skill-based resources.
- *
- * Resources provide application-controlled access to skill content,
- * complementing the model-controlled tool access.
- *
- * All resources use templates with dynamic list callbacks to support
- * skill updates when MCP roots change.
+ * MCP Resource registration for skill-based resources, aligned with SEP-2640
+ * (Skills Extension).
  *
  * URI Scheme:
- *   skill://{skillName}   -> SKILL.md content (template)
- *   skill://{skillName}/  -> Collection: all files in skill directory
+ *   skill://<skill-path>/SKILL.md   -> Each skill's SKILL.md (listed in resources/list)
+ *   skill://<skill-path>/<file>     -> Individual files inside a skill (template-resolvable, not listed)
+ *   skill://index.json              -> SEP-2640 discovery index (application/json)
  *
- * Note: Individual file URIs (skill://{skillName}/{path}) are not listed
- * as resources to reduce noise. Use the skill-resource tool to fetch
- * specific files on demand.
+ * <skill-path> is computed by getSkillPath(): "<prefix>/<baseName>" for prefixed
+ * skills (final segment always equals frontmatter `name`), or just "<baseName>"
+ * for bundled skills with empty prefix.
  */
 
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { McpServer, ResourceTemplate } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { Resource } from "@modelcontextprotocol/sdk/types.js";
-import { loadSkillContent, getResourceAnnotations } from "./skill-discovery.js";
-import { isPathWithinBase, listSkillFiles, MAX_FILE_SIZE, SkillState } from "./skill-tool.js";
+import {
+  loadSkillContent,
+  getResourceAnnotations,
+  buildSkillResourceUri,
+  parseSkillResourceUri,
+  buildSkillIndex,
+  getSkillPath,
+} from "./skill-discovery.js";
+import { isPathWithinBase, MAX_FILE_SIZE, SkillState } from "./skill-tool.js";
 
 /**
  * Get MIME type based on file extension.
@@ -47,140 +50,47 @@ function getMimeType(filePath: string): string {
 
 /**
  * Register skill resources with the MCP server.
- *
- * All resources use templates with dynamic list callbacks to support
- * skill updates when MCP roots change.
- *
- * @param server - The McpServer instance
- * @param skillState - Shared state object (allows dynamic updates)
  */
 export function registerSkillResources(
   server: McpServer,
   skillState: SkillState
 ): void {
-  // Register template for individual skill SKILL.md files
+  registerSkillIndexResource(server, skillState);
   registerSkillTemplate(server, skillState);
-
-  // Register collection resource for skill directories
-  registerSkillDirectoryCollection(server, skillState);
-
-  // Note: Individual file resources (skill://{name}/{path}) are intentionally
-  // not registered to reduce noise. Use the skill-resource tool to fetch
-  // specific files on demand.
 }
 
 /**
- * Register a collection resource for skill directories.
- *
- * URI Pattern: skill://{skillName}/
- *
- * Returns all files in the skill directory (excluding SKILL.md) in a single request.
- * This allows clients to fetch all resource files for a skill at once.
+ * Register the SEP-2640 discovery index at skill://index.json.
  */
-function registerSkillDirectoryCollection(
+function registerSkillIndexResource(
   server: McpServer,
   skillState: SkillState
 ): void {
   server.registerResource(
-    "Skill Directory",
-    new ResourceTemplate("skill://{skillName}/", {
-      list: async () => {
-        // Return one entry per skill (the directory collection)
-        const resources: Resource[] = [];
-
-        for (const [name, skill] of skillState.skillMap) {
-          const { annotations, size } = getResourceAnnotations(skill, 0.3);
-          const resource: Resource = {
-            uri: `skill://${encodeURIComponent(name)}/`,
-            name: `${name}/`,
-            mimeType: "text/plain",
-            description: `All files in ${name} skill directory`,
-            annotations,
-          };
-          if (size !== undefined) {
-            resource.size = size;
-          }
-          resources.push(resource);
-        }
-
-        return { resources };
-      },
-      complete: {
-        skillName: (value: string) => {
-          const names = Array.from(skillState.skillMap.keys());
-          return names.filter((n) => n.toLowerCase().includes(value.toLowerCase()));
-        },
-      },
-    }),
+    "Skill Index",
+    "skill://index.json",
     {
-      mimeType: "text/plain",
-      description: "Collection of all files in a skill directory (excluding SKILL.md)",
+      mimeType: "application/json",
+      description: "SEP-2640 Agent Skills discovery index",
+      annotations: { audience: ["assistant", "user"], priority: 0.5 },
     },
-    async (resourceUri) => {
-      // Extract skill name from URI
-      const uriStr = resourceUri.toString();
-      const match = uriStr.match(/^skill:\/\/([^/]+)\/$/);
-
-      if (!match) {
-        throw new Error(`Invalid skill directory URI: ${uriStr}`);
-      }
-
-      const skillName = decodeURIComponent(match[1]);
-      const skill = skillState.skillMap.get(skillName);
-
-      if (!skill) {
-        const available = Array.from(skillState.skillMap.keys()).join(", ");
-        throw new Error(`Skill "${skillName}" not found. Available: ${available || "none"}`);
-      }
-
-      const skillDir = path.dirname(skill.path);
-      const files = listSkillFiles(skillDir);
-
-      const contents = [];
-      for (const file of files) {
-        const fullPath = path.join(skillDir, file);
-
-        // Security: Validate path is within skill directory
-        if (!isPathWithinBase(fullPath, skillDir)) {
-          continue; // Skip files outside skill directory
-        }
-
-        try {
-          const stat = fs.statSync(fullPath);
-
-          // Skip symlinks and directories
-          if (stat.isSymbolicLink() || stat.isDirectory()) {
-            continue;
-          }
-
-          // Check file size
-          if (stat.size > MAX_FILE_SIZE) {
-            continue; // Skip large files
-          }
-
-          const content = fs.readFileSync(fullPath, "utf-8");
-          contents.push({
-            uri: `skill://${encodeURIComponent(skillName)}/${file}`,
-            mimeType: getMimeType(file),
-            text: content,
-          });
-        } catch (error) {
-          // Skip files that fail to load
-          console.error(`Failed to load file "${file}" in skill "${skillName}":`, error);
-        }
-      }
-
-      return { contents };
-    }
+    async (resourceUri) => ({
+      contents: [
+        {
+          uri: resourceUri.toString(),
+          mimeType: "application/json",
+          text: JSON.stringify(buildSkillIndex(skillState.skillMap), null, 2),
+        },
+      ],
+    })
   );
 }
 
 /**
- * Register a template for individual skill SKILL.md resources.
- *
- * URI Pattern: skill://{skillName}
- *
- * Uses a template with a list callback to dynamically return available skills.
+ * Register a single template that covers every skill:// URI other than
+ * the exact index resource. The list callback enumerates only SKILL.md
+ * resources (one per skill); the read handler dispatches between SKILL.md
+ * and supporting-file reads.
  */
 function registerSkillTemplate(
   server: McpServer,
@@ -188,16 +98,14 @@ function registerSkillTemplate(
 ): void {
   server.registerResource(
     "Skill",
-    new ResourceTemplate("skill://{skillName}", {
+    new ResourceTemplate("skill://{+skillUri}", {
       list: async () => {
-        // Dynamically return current skills
         const resources: Resource[] = [];
-
-        for (const [name, skill] of skillState.skillMap) {
+        for (const skill of skillState.skillMap.values()) {
           const { annotations, size } = getResourceAnnotations(skill, 0.8);
           const resource: Resource = {
-            uri: `skill://${encodeURIComponent(name)}`,
-            name,
+            uri: buildSkillResourceUri(skill, "SKILL.md"),
+            name: skill.baseName,
             mimeType: "text/markdown",
             description: skill.description,
             annotations,
@@ -207,53 +115,84 @@ function registerSkillTemplate(
           }
           resources.push(resource);
         }
-
         return { resources };
       },
       complete: {
-        skillName: (value: string) => {
-          const names = Array.from(skillState.skillMap.keys());
-          return names.filter((name) => name.toLowerCase().includes(value.toLowerCase()));
+        skillUri: (value: string) => {
+          // Suggest <skill-path>/SKILL.md for each skill, filtered by substring.
+          const v = value.toLowerCase();
+          return Array.from(skillState.skillMap.values())
+            .map((skill) => `${getSkillPath(skill)}/SKILL.md`)
+            .filter((u) => u.toLowerCase().includes(v));
         },
       },
     }),
     {
       mimeType: "text/markdown",
-      description: "SKILL.md content for a skill",
+      description: "Agent Skill resource (SEP-2640)",
     },
     async (resourceUri) => {
-      // Extract skill name from URI
       const uriStr = resourceUri.toString();
-      const match = uriStr.match(/^skill:\/\/([^/]+)$/);
+      const parsed = parseSkillResourceUri(uriStr, skillState.skillMap);
 
-      if (!match) {
-        throw new Error(`Invalid skill URI: ${uriStr}`);
+      if (!parsed) {
+        throw new Error(`Skill resource not found for URI: ${uriStr}`);
       }
 
-      const skillName = decodeURIComponent(match[1]);
-      const skill = skillState.skillMap.get(skillName);
+      const { skill, fileRelPath } = parsed;
 
-      if (!skill) {
-        const available = Array.from(skillState.skillMap.keys()).join(", ");
-        throw new Error(`Skill "${skillName}" not found. Available: ${available || "none"}`);
+      if (fileRelPath === "SKILL.md") {
+        try {
+          const content = loadSkillContent(skill.path);
+          return {
+            contents: [
+              {
+                uri: uriStr,
+                mimeType: "text/markdown",
+                text: content,
+              },
+            ],
+          };
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error);
+          throw new Error(`Failed to load skill "${skill.baseName}": ${message}`);
+        }
       }
 
+      // Supporting file inside the skill directory.
+      const skillDir = path.dirname(skill.path);
+      const fullPath = path.resolve(skillDir, fileRelPath);
+
+      if (!isPathWithinBase(fullPath, skillDir)) {
+        throw new Error(`Path traversal blocked: ${fileRelPath}`);
+      }
+
+      let stat: fs.Stats;
       try {
-        const content = loadSkillContent(skill.path);
-        return {
-          contents: [
-            {
-              uri: uriStr,
-              mimeType: "text/markdown",
-              text: content,
-            },
-          ],
-        };
-      } catch (error) {
-        const message = error instanceof Error ? error.message : String(error);
-        throw new Error(`Failed to load skill "${skillName}": ${message}`);
+        stat = fs.statSync(fullPath);
+      } catch {
+        throw new Error(`File not found: ${fileRelPath}`);
       }
+
+      if (stat.isSymbolicLink() || stat.isDirectory()) {
+        throw new Error(`Not a readable file: ${fileRelPath}`);
+      }
+      if (stat.size > MAX_FILE_SIZE) {
+        throw new Error(
+          `File too large (${stat.size} bytes, max ${MAX_FILE_SIZE}): ${fileRelPath}`
+        );
+      }
+
+      const content = fs.readFileSync(fullPath, "utf-8");
+      return {
+        contents: [
+          {
+            uri: uriStr,
+            mimeType: getMimeType(fileRelPath),
+            text: content,
+          },
+        ],
+      };
     }
   );
 }
-

--- a/src/subscriptions.test.ts
+++ b/src/subscriptions.test.ts
@@ -1,49 +1,79 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
 import { resolveUriToFilePaths } from "./subscriptions.js";
-import { createTestSkill, createTestSkillState } from "./__test-helpers__/helpers.js";
+import { BUNDLED_SKILL_SOURCE } from "./skill-discovery.js";
+import {
+  createTestSkill,
+  createTestSkillState,
+  createTestSource,
+} from "./__test-helpers__/helpers.js";
 
-describe("resolveUriToFilePaths", () => {
-  const skill1 = createTestSkill({
+describe("resolveUriToFilePaths (SEP-2640)", () => {
+  const bundled = createTestSkill({
     name: "my-skill",
+    baseName: "my-skill",
     path: "/skills/my-skill/SKILL.md",
+    source: BUNDLED_SKILL_SOURCE,
   });
-  const skill2 = createTestSkill({
-    name: "other-skill",
+  const prefixed = createTestSkill({
+    name: "my-project__other-skill",
+    baseName: "other-skill",
     path: "/skills/other-skill/SKILL.md",
+    source: createTestSource({ prefix: "my-project" }),
   });
-  const state = createTestSkillState([skill1, skill2]);
+  const state = createTestSkillState([bundled, prefixed]);
 
-  it("resolves skill:// to all skill directory paths", () => {
-    const paths = resolveUriToFilePaths("skill://", state);
+  it("resolves skill://index.json to every SKILL.md path", () => {
+    const paths = resolveUriToFilePaths("skill://index.json", state);
     expect(paths).toHaveLength(2);
-    expect(paths).toContain(path.dirname(skill1.path));
-    expect(paths).toContain(path.dirname(skill2.path));
+    expect(paths).toContain(bundled.path);
+    expect(paths).toContain(prefixed.path);
   });
 
-  it("resolves skill://name to SKILL.md path", () => {
-    const paths = resolveUriToFilePaths("skill://my-skill", state);
-    expect(paths).toEqual(["/skills/my-skill/SKILL.md"]);
+  it("resolves skill://<base>/SKILL.md (bundled) to that SKILL.md", () => {
+    const paths = resolveUriToFilePaths("skill://my-skill/SKILL.md", state);
+    expect(paths).toEqual([bundled.path]);
   });
 
-  it("resolves skill://name/ to skill directory path", () => {
-    const paths = resolveUriToFilePaths("skill://my-skill/", state);
-    expect(paths).toEqual([path.dirname(skill1.path)]);
+  it("resolves skill://<prefix>/<base>/SKILL.md to that SKILL.md", () => {
+    const paths = resolveUriToFilePaths(
+      "skill://my-project/other-skill/SKILL.md",
+      state
+    );
+    expect(paths).toEqual([prefixed.path]);
   });
 
-  it("resolves skill://name/path to absolute file path", () => {
-    const paths = resolveUriToFilePaths("skill://my-skill/scripts/example.py", state);
+  it("resolves skill://<path>/<file> to absolute file path", () => {
+    const paths = resolveUriToFilePaths(
+      "skill://my-skill/scripts/example.py",
+      state
+    );
     expect(paths).toHaveLength(1);
     expect(paths[0]).toBe(path.resolve("/skills/my-skill", "scripts/example.py"));
   });
 
-  it("returns empty array for unknown skill name", () => {
-    const paths = resolveUriToFilePaths("skill://nonexistent", state);
+  it("rejects path traversal", () => {
+    const paths = resolveUriToFilePaths(
+      "skill://my-skill/..%2F..%2Fetc%2Fpasswd",
+      state
+    );
     expect(paths).toEqual([]);
   });
 
-  it("returns empty array for unmatched URI patterns", () => {
-    const paths = resolveUriToFilePaths("http://example.com", state);
+  it("returns [] for unknown skill", () => {
+    const paths = resolveUriToFilePaths("skill://nonexistent/SKILL.md", state);
     expect(paths).toEqual([]);
+  });
+
+  it("returns [] for legacy bare skill://name URI", () => {
+    expect(resolveUriToFilePaths("skill://my-skill", state)).toEqual([]);
+  });
+
+  it("returns [] for legacy skill://name/ URI", () => {
+    expect(resolveUriToFilePaths("skill://my-skill/", state)).toEqual([]);
+  });
+
+  it("returns [] for non-skill scheme", () => {
+    expect(resolveUriToFilePaths("http://example.com", state)).toEqual([]);
   });
 });

--- a/src/subscriptions.ts
+++ b/src/subscriptions.ts
@@ -5,11 +5,10 @@
  * using chokidar. When files change, sends notifications/resources/updated
  * to subscribed clients.
  *
- * URI patterns supported:
- * - skill://              → Watch all skill directories
- * - skill://{name}        → Watch that skill's SKILL.md
- * - skill://{name}/       → Watch entire skill directory (directory collection)
- * - skill://{name}/{path} → Watch specific file (subscribable but not listed as resource)
+ * URI patterns supported (SEP-2640):
+ * - skill://index.json              → Watch every SKILL.md (any skill change re-fires)
+ * - skill://<skill-path>/SKILL.md   → Watch that skill's SKILL.md
+ * - skill://<skill-path>/<file>     → Watch a specific file inside the skill directory
  */
 
 import chokidar, { FSWatcher } from "chokidar";
@@ -20,6 +19,7 @@ import {
   UnsubscribeRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { SkillState, isPathWithinBase } from "./skill-tool.js";
+import { parseSkillResourceUri } from "./skill-discovery.js";
 
 /**
  * Manages active subscriptions and their associated file watchers.
@@ -64,49 +64,26 @@ export function resolveUriToFilePaths(
   uri: string,
   skillState: SkillState
 ): string[] {
-  // skill:// → Watch all skill directories
-  if (uri === "skill://") {
-    const paths: string[] = [];
-    for (const skill of skillState.skillMap.values()) {
-      paths.push(path.dirname(skill.path)); // Watch entire skill directory
-    }
-    return paths;
+  // SEP-2640 index → watch every SKILL.md so any skill change re-fires.
+  if (uri === "skill://index.json") {
+    return Array.from(skillState.skillMap.values()).map((s) => s.path);
   }
 
-  // skill://{skillName} → Just the SKILL.md file
-  const skillMatch = uri.match(/^skill:\/\/([^/]+)$/);
-  if (skillMatch) {
-    const skillName = decodeURIComponent(skillMatch[1]);
-    const skill = skillState.skillMap.get(skillName);
-    return skill ? [skill.path] : [];
+  const parsed = parseSkillResourceUri(uri, skillState.skillMap);
+  if (!parsed) return [];
+
+  const { skill, fileRelPath } = parsed;
+
+  // skill://<skill-path>/SKILL.md → that skill's SKILL.md
+  if (fileRelPath === "SKILL.md") {
+    return [skill.path];
   }
 
-  // skill://{skillName}/ → Watch entire skill directory (directory collection)
-  const dirMatch = uri.match(/^skill:\/\/([^/]+)\/$/);
-  if (dirMatch) {
-    const skillName = decodeURIComponent(dirMatch[1]);
-    const skill = skillState.skillMap.get(skillName);
-    return skill ? [path.dirname(skill.path)] : [];
-  }
-
-  // skill://{skillName}/{path} → Specific file
-  const fileMatch = uri.match(/^skill:\/\/([^/]+)\/(.+)$/);
-  if (fileMatch) {
-    const skillName = decodeURIComponent(fileMatch[1]);
-    const filePath = fileMatch[2];
-    const skill = skillState.skillMap.get(skillName);
-    if (!skill) return [];
-
-    const skillDir = path.dirname(skill.path);
-    const fullPath = path.resolve(skillDir, filePath);
-
-    // Security check: ensure path is within skill directory
-    if (!isPathWithinBase(fullPath, skillDir)) return [];
-
-    return [fullPath];
-  }
-
-  return [];
+  // skill://<skill-path>/<file> → specific file inside the skill directory
+  const skillDir = path.dirname(skill.path);
+  const fullPath = path.resolve(skillDir, fileRelPath);
+  if (!isPathWithinBase(fullPath, skillDir)) return [];
+  return [fullPath];
 }
 
 /**


### PR DESCRIPTION
## Summary

- Replace the existing `skill://{name}` and `skill://{name}/` URIs with the [SEP-2640](https://github.com/modelcontextprotocol/modelcontextprotocol/pull/2640) shape: `skill://<skill-path>/SKILL.md` for the skill markdown, sibling URIs for supporting files, and a new `skill://index.json` discovery resource.
- Declare the SEP extension capability `extensions["io.modelcontextprotocol/skills"]: {}` in the `initialize` response.
- Add four helpers (`getSkillPath`, `buildSkillResourceUri`, `parseSkillResourceUri`, `buildSkillIndex`) in `skill-discovery.ts` and reuse them from resources, subscriptions, and prompts.

This is a breaking change to the URI scheme. Pre-1.0, draft SEP, no backward-compat shims.

## Resource shape after this PR

| URI | Listed? | Returns |
|---|---|---|
| `skill://<skill-path>/SKILL.md` | yes | SKILL.md (`text/markdown`), `name` and `description` from frontmatter |
| `skill://<skill-path>/<file-path>` | no (template-resolvable) | Supporting file with extension-derived MIME type |
| `skill://index.json` | yes | SEP discovery index (`application/json`) |

`<skill-path>` is `<prefix>/<baseName>` for prefixed skills (local: dir basename, GitHub: `owner-repo`) or just `<baseName>` for bundled — final segment always equals the frontmatter ` + '`name`' + ` per SEP.

## Out of scope

- Archive (`type: "archive"`) entries in the index.
- ` + '`mcp-resource-template`' + ` index entries.
- ` + '`_meta`' + ` projection of additional frontmatter (commit ` + '`207b3fd`' + ` removed it; reintroducing would contradict that direction).

## Test plan

- [x] ` + '`npm run build`' + ` clean
- [x] ` + '`npm test`' + ` — 168/168 passing (rewrote ` + '`skill-resources.test.ts`' + ` and ` + '`subscriptions.test.ts`' + `, extended ` + '`skill-discovery.test.ts`' + ` with helper coverage)
- [ ] Manual via MCP Inspector:
  - [ ] ` + '`initialize`' + ` advertises ` + '`extensions["io.modelcontextprotocol/skills"]`' + `
  - [ ] ` + '`resources/list`' + ` shows one ` + '`skill://<path>/SKILL.md`' + ` per skill plus ` + '`skill://index.json`' + `; no legacy ` + '`skill://name`' + ` or ` + '`skill://name/`' + `
  - [ ] ` + '`resources/read`' + ` of ` + '`skill://index.json`' + ` returns SEP-shaped JSON
  - [ ] ` + '`resources/read`' + ` of ` + '`skill://<bundled>/SKILL.md`' + ` returns markdown
  - [ ] ` + '`resources/read`' + ` of a sibling file (e.g., ` + '`skill://<path>/scripts/example.py`' + `) returns content
  - [ ] Subscribe to ` + '`skill://index.json`' + `; modify any SKILL.md → notification fires
  - [ ] Add a new SKILL.md on disk → ` + '`notifications/resources/list_changed`' + ` and ` + '`notifications/resources/updated`' + ` for ` + '`skill://index.json`' + ` both fire

🤖 Generated with [Claude Code](https://claude.com/claude-code)