### PR TITLE
Bump version to 0.10.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilljack/mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP server that discovers and serves Agent Skills. I know kung fu.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
Bump for the SEP-2640 resource-layer migration merged in #59.

Pre-1.0 minor bump because the change is breaking: `skill://{name}` and `skill://{name}/` URIs are gone; resources now live at `skill://<skill-path>/SKILL.md`, supporting files at sibling URIs, and a new `skill://index.json` discovery resource.

Build clean, 168/168 tests passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)