### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilljack/mcp",
-  "version": "0.10.0",
+  "version": "0.11.0",
   "description": "MCP server that discovers and serves Agent Skills. I know kung fu.",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Why

`@skilljack/mcp@0.10.0` was already published to npm on 2026-04-16 from a since-discarded commit (`8aa91c6`). Attempting to publish the SEP-2640 release as 0.10.0 fails with "You cannot publish over the previously published versions".

Bumping to `0.11.0` to release the [SEP-2640 resource-layer migration](https://github.com/olaservo/skilljack-mcp/pull/59).

## Test plan

- [x] `npm run build` clean
- [x] `npm test` — 168/168 passing
- [x] `npm pack --dry-run` shows correct file set

## Follow-up

The existing `v0.10.0` git tag and GitHub release currently advertise the SEP-2640 changelog but `npm install @skilljack/mcp@0.10.0` returns the older pre-SEP code. Worth deciding separately whether to restore the `v0.10.0` tag/release to its pre-SEP state for accuracy. Out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)