### PR TITLE
Add .well-known/agent-skills/ discovery as a new skill source

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -12,27 +12,39 @@
 - `SKILLS_DIR` - Comma-separated list of skill directories
 - `SKILLJACK_STATIC` - Set to `true`, `1`, or `yes` to enable static mode
 - `MAX_FILE_SIZE_MB` - Maximum file size for skill resources (default: 1MB)
+- `WELL_KNOWN_ALLOWED_ORIGINS` - Comma-separated origins (e.g. `https://example.com`) permitted as well-known publishers. Default-deny.
+- `WELL_KNOWN_POLL_INTERVAL_MS` - Well-known poll cadence (default 300000, `0` disables)
+- `WELL_KNOWN_MAX_ARTIFACT_MB` - Per-artifact byte cap (default 10)
+- `WELL_KNOWN_MAX_UNPACKED_MB` - Archive uncompressed size cap (default 50)
+- `WELL_KNOWN_ALLOW_HTTP` - `1`/`true`/`yes` to permit `http://` origins (dev only)
 
 **CLI Options:**
-- Positional args: Skill directories
+- Positional args: Skill directories, GitHub URLs, or well-known publisher URLs (e.g. `https://example.com/.well-known/agent-skills/`)
 - `--static`: Enable static mode (freeze skills at startup, no file watching)
 
 ## Project Structure
 
 ```
 src/
-├── index.ts           # Entry point, server setup, file watching, stdio transport
-├── skill-discovery.ts # YAML frontmatter parsing, XML generation
-├── skill-tool.ts      # MCP tools: skill, skill-resource
-├── skill-prompts.ts   # MCP Prompts: /skill with auto-completion, per-skill prompts
-├── skill-resources.ts # MCP Resources: SEP-2640 skill:// URI scheme + skill://index.json
-└── subscriptions.ts   # File watching, resource subscriptions
+├── index.ts             # Entry point, server setup, file watching, stdio transport
+├── skill-discovery.ts   # YAML frontmatter parsing, XML generation
+├── skill-tool.ts        # MCP tools: skill, skill-resource
+├── skill-prompts.ts     # MCP Prompts: /skill with auto-completion, per-skill prompts
+├── skill-resources.ts   # MCP Resources: SEP-2640 skill:// URI scheme + skill://index.json
+├── subscriptions.ts     # File watching, resource subscriptions
+├── github-config.ts     # GitHub URL detection, parsing, allowlist
+├── github-sync.ts       # Clone/pull GitHub repos into the cache
+├── github-polling.ts    # Periodic GitHub update checks
+├── well-known-config.ts # Well-known URL detection, parsing, allowlist
+├── well-known-sync.ts   # Fetch + verify (SHA-256) + safely extract publisher artifacts
+└── well-known-polling.ts # Periodic well-known index re-fetch (ETag/If-None-Match)
 ```
 
 ## Key Abstractions
 
 **SkillSource** - Origin info with namespace prefix:
-- `prefix: string` - Namespace prefix (local: dir basename, GitHub: `owner-repo`, bundled: `""`)
+- `prefix: string` - Namespace prefix (local: dir basename, GitHub: `owner-repo`, well-known: `<host-slug>[_<base-path-slug>]`, bundled: `""`)
+- `type: "local" | "github" | "bundled" | "well-known"` - Which source pulled the skill
 
 **SkillState** - Shared state:
 - `skillMap: Map<string, SkillMetadata>` - qualified name → skill lookup
@@ -77,6 +89,29 @@ src/
 | `refreshPrompts()` | skill-prompts.ts | Update prompts when skills change |
 | `getPromptDescription()` | skill-prompts.ts | Usage text + skill list for prompt desc |
 | `refreshSubscriptions()` | subscriptions.ts | Update watchers when skills change |
+| `parseWellKnownUrl()` | well-known-config.ts | Normalize a publisher URL into `{origin, basePath}`, auto-appending `/.well-known/agent-skills` |
+| `isOriginAllowed()` | well-known-config.ts | Default-deny allowlist check for well-known origins |
+| `syncWellKnown()` | well-known-sync.ts | Fetch index.json, verify each entry's SHA-256 digest, write/extract into the cache |
+| `validateIndexDocument()` | well-known-sync.ts | Shape-check a parsed index document and reject malformed entries |
+| `archiveFormatFromUrl()` | well-known-sync.ts | Pick `tar.gz` / `zip` / `null` from an artifact URL |
+| `hasRemoteUpdates()` | well-known-sync.ts | Conditional GET on index.json (ETag/If-Modified-Since) |
+| `createWellKnownPollingManager()` | well-known-polling.ts | Periodic index re-check, mirrors GitHub polling shape |
+
+## Well-Known Discovery (.well-known/agent-skills/)
+
+Implements [the agent-skills discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc). Configure a publisher origin:
+
+```bash
+WELL_KNOWN_ALLOWED_ORIGINS=https://example.com \
+  skilljack-mcp https://example.com/.well-known/agent-skills/
+```
+
+- **Default-deny**: origins must be on the allowlist (env var or `wellKnownAllowedOrigins` in `~/.skilljack/config.json`).
+- **Digest verification**: every artifact byte stream is SHA-256-hashed and compared against the index entry's `digest` (`sha256:<64 hex>`). Mismatch → entry is rejected and not written to disk.
+- **Archive safety**: `.tar.gz` (via `tar`) and `.zip` (via `yauzl-promise`) are extracted with rejection of absolute paths, parent traversal (`..`), symlinks/hardlinks, and uncompressed sizes over `WELL_KNOWN_MAX_UNPACKED_MB`.
+- **Cache layout**: `~/.skilljack/well-known-cache/<host-slug>[_<path-slug>]/skills/<skill-name>/SKILL.md`. The `skills/` root is added to `currentSkillsDirs` so `discoverSkills()` picks them up like any local source.
+- **Conditional refetch**: `index.json` ETag/Last-Modified are stored alongside the cache and replayed via `If-None-Match` / `If-Modified-Since` on the next poll.
+- **Pruning**: skills removed from the index have their per-skill cache directories deleted on the next sync.
 
 ## Modification Guide
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ GITHUB_ALLOWED_ORGS=acme skilljack-mcp github.com/acme/skills
 
 # Well-known publisher (allowlisted via WELL_KNOWN_ALLOWED_ORIGINS).
 # Each entry's SHA-256 digest is verified against the published index.
+# Every fetched URL — the index, each artifact, and any redirect target — must
+# match an allowlisted origin, so if a publisher serves artifacts from a
+# separate CDN origin, add that origin to the list too (comma-separated).
 WELL_KNOWN_ALLOWED_ORIGINS=https://example.com \
   skilljack-mcp https://example.com/.well-known/agent-skills/
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ skilljack-mcp /path/to/skills
 # Multiple directories
 skilljack-mcp /path/to/skills /path/to/more/skills
 
+# GitHub repository (allowlisted via GITHUB_ALLOWED_ORGS / _USERS)
+GITHUB_ALLOWED_ORGS=acme skilljack-mcp github.com/acme/skills
+
+# Well-known publisher (allowlisted via WELL_KNOWN_ALLOWED_ORIGINS).
+# Each entry's SHA-256 digest is verified against the published index.
+WELL_KNOWN_ALLOWED_ORIGINS=https://example.com \
+  skilljack-mcp https://example.com/.well-known/agent-skills/
+
 # Using environment variable
 SKILLS_DIR=/path/to/skills skilljack-mcp
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,21 @@
 {
   "name": "@skilljack/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@skilljack/mcp",
-      "version": "0.11.0",
+      "version": "0.12.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/ext-apps": "^1.0.0",
         "@modelcontextprotocol/sdk": "^1.29.0",
         "chokidar": "^5.0.0",
         "simple-git": "^3.27.0",
+        "tar": "^7.4.0",
         "yaml": "^2.7.0",
+        "yauzl-promise": "^4.0.0",
         "zod": "^4.0.0"
       },
       "bin": {
@@ -22,6 +24,7 @@
       "devDependencies": {
         "@anthropic-ai/claude-agent-sdk": "^0.2.114",
         "@types/node": "^22.10.0",
+        "@types/tar": "^6.1.13",
         "@vitest/coverage-v8": "^4.1.0",
         "cross-env": "^7.0.3",
         "tsx": "^4.19.2",
@@ -252,6 +255,37 @@
       "license": "MIT",
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.2.tgz",
+      "integrity": "sha512-TC8MkTuZUtcTSiFeuC0ksCh9QIJ5+F21MvZ4Wn4ORfYaFJ/0dsiudv5tVkejgwZlwQ39jL9WWDe2lz8x0WglOA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.2.tgz",
+      "integrity": "sha512-kyOl3X0DuTiT1h2ft8r2fYO8JYtU9a9Xis/zBSiGArNaagCOWx90N1k2wxp18czFDH+OgcWGb5ZP/XMt3dcyPA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -706,6 +740,23 @@
         "hono": "^4"
       }
     },
+    "node_modules/@isaacs/fs-minipass": {
+      "version": "4.0.1",
+      "license": "ISC",
+      "dependencies": {
+        "minipass": "^7.0.4"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@isaacs/fs-minipass/node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/@jridgewell/resolve-uri": {
       "version": "3.1.2",
       "dev": true,
@@ -816,6 +867,267 @@
         "zod": {
           "optional": false
         }
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "0.2.12",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
+      "integrity": "sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.4.3",
+        "@emnapi/runtime": "^1.4.3",
+        "@tybys/wasm-util": "^0.10.0"
+      }
+    },
+    "node_modules/@node-rs/crc32": {
+      "version": "1.10.6",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@node-rs/crc32-android-arm-eabi": "1.10.6",
+        "@node-rs/crc32-android-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-arm64": "1.10.6",
+        "@node-rs/crc32-darwin-x64": "1.10.6",
+        "@node-rs/crc32-freebsd-x64": "1.10.6",
+        "@node-rs/crc32-linux-arm-gnueabihf": "1.10.6",
+        "@node-rs/crc32-linux-arm64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-arm64-musl": "1.10.6",
+        "@node-rs/crc32-linux-x64-gnu": "1.10.6",
+        "@node-rs/crc32-linux-x64-musl": "1.10.6",
+        "@node-rs/crc32-wasm32-wasi": "1.10.6",
+        "@node-rs/crc32-win32-arm64-msvc": "1.10.6",
+        "@node-rs/crc32-win32-ia32-msvc": "1.10.6",
+        "@node-rs/crc32-win32-x64-msvc": "1.10.6"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm-eabi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm-eabi/-/crc32-android-arm-eabi-1.10.6.tgz",
+      "integrity": "sha512-vZAMuJXm3TpWPOkkhxdrofWDv+Q+I2oO7ucLRbXyAPmXFNDhHtBxbO1rk9Qzz+M3eep8ieS4/+jCL1Q0zacNMQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-android-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-android-arm64/-/crc32-android-arm64-1.10.6.tgz",
+      "integrity": "sha512-Vl/JbjCinCw/H9gEpZveWCMjxjcEChDcDBM8S4hKay5yyoRCUHJPuKr4sjVDBeOm+1nwU3oOm6Ca8dyblwp4/w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-arm64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-arm64/-/crc32-darwin-arm64-1.10.6.tgz",
+      "integrity": "sha512-kARYANp5GnmsQiViA5Qu74weYQ3phOHSYQf0G+U5wB3NB5JmBHnZcOc46Ig21tTypWtdv7u63TaltJQE41noyg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-darwin-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-darwin-x64/-/crc32-darwin-x64-1.10.6.tgz",
+      "integrity": "sha512-Q99bevJVMfLTISpkpKBlXgtPUItrvTWKFyiqoKH5IvscZmLV++NH4V13Pa17GTBmv9n18OwzgQY4/SRq6PQNVA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-freebsd-x64": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-freebsd-x64/-/crc32-freebsd-x64-1.10.6.tgz",
+      "integrity": "sha512-66hpawbNjrgnS9EDMErta/lpaqOMrL6a6ee+nlI2viduVOmRZWm9Rg9XdGTK/+c4bQLdtC6jOd+Kp4EyGRYkAg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm-gnueabihf": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm-gnueabihf/-/crc32-linux-arm-gnueabihf-1.10.6.tgz",
+      "integrity": "sha512-E8Z0WChH7X6ankbVm8J/Yym19Cq3otx6l4NFPS6JW/cWdjv7iw+Sps2huSug+TBprjbcEA+s4TvEwfDI1KScjg==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-gnu/-/crc32-linux-arm64-gnu-1.10.6.tgz",
+      "integrity": "sha512-LmWcfDbqAvypX0bQjQVPmQGazh4dLiVklkgHxpV4P0TcQ1DT86H/SWpMBMs/ncF8DGuCQ05cNyMv1iddUDugoQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-arm64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-arm64-musl/-/crc32-linux-arm64-musl-1.10.6.tgz",
+      "integrity": "sha512-k8ra/bmg0hwRrIEE8JL1p32WfaN9gDlUUpQRWsbxd1WhjqvXea7kKO6K4DwVxyxlPhBS9Gkb5Urq7Y4mXANzaw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-gnu": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-gnu/-/crc32-linux-x64-gnu-1.10.6.tgz",
+      "integrity": "sha512-IfjtqcuFK7JrSZ9mlAFhb83xgium30PguvRjIMI45C3FJwu18bnLk1oR619IYb/zetQT82MObgmqfKOtgemEKw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-linux-x64-musl": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-linux-x64-musl/-/crc32-linux-x64-musl-1.10.6.tgz",
+      "integrity": "sha512-LbFYsA5M9pNunOweSt6uhxenYQF94v3bHDAQRPTQ3rnjn+mK6IC7YTAYoBjvoJP8lVzcvk9hRj8wp4Jyh6Y80g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-wasm32-wasi": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-wasm32-wasi/-/crc32-wasm32-wasi-1.10.6.tgz",
+      "integrity": "sha512-KaejdLgHMPsRaxnM+OG9L9XdWL2TabNx80HLdsCOoX9BVhEkfh39OeahBo8lBmidylKbLGMQoGfIKDjq0YMStw==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^0.2.5"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-arm64-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-arm64-msvc/-/crc32-win32-arm64-msvc-1.10.6.tgz",
+      "integrity": "sha512-x50AXiSxn5Ccn+dCjLf1T7ZpdBiV1Sp5aC+H2ijhJO4alwznvXgWbopPRVhbp2nj0i+Gb6kkDUEyU+508KAdGQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-ia32-msvc": {
+      "version": "1.10.6",
+      "resolved": "https://registry.npmjs.org/@node-rs/crc32-win32-ia32-msvc/-/crc32-win32-ia32-msvc-1.10.6.tgz",
+      "integrity": "sha512-DpDxQLaErJF9l36aghe1Mx+cOnYLKYo6qVPqPL9ukJ5rAGLtCdU0C+Zoi3gs9ySm8zmbFgazq/LvmsZYU42aBw==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@node-rs/crc32-win32-x64-msvc": {
+      "version": "1.10.6",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@oven/bun-darwin-aarch64": {
@@ -1321,6 +1633,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
     "node_modules/@types/chai": {
       "version": "5.2.3",
       "dev": true,
@@ -1348,6 +1670,15 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/tar": {
+      "version": "6.1.13",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "minipass": "^4.0.0"
       }
     },
     "node_modules/@vitest/coverage-v8": {
@@ -1628,6 +1959,13 @@
         "url": "https://paulmillr.com/funding/"
       }
     },
+    "node_modules/chownr": {
+      "version": "3.0.0",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.1.0",
       "license": "MIT",
@@ -1720,6 +2058,36 @@
         }
       }
     },
+    "node_modules/define-data-property": {
+      "version": "1.1.4",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/define-properties": {
+      "version": "1.2.1",
+      "license": "MIT",
+      "dependencies": {
+        "define-data-property": "^1.0.1",
+        "has-property-descriptors": "^1.0.0",
+        "object-keys": "^1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "license": "MIT",
@@ -1754,8 +2122,6 @@
     },
     "node_modules/es-define-property": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
-      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -1763,8 +2129,6 @@
     },
     "node_modules/es-errors": {
       "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
-      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2082,10 +2446,22 @@
         "url": "https://github.com/privatenumber/get-tsconfig?sponsor=1"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.4",
+      "license": "MIT",
+      "dependencies": {
+        "define-properties": "^1.2.1",
+        "gopd": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
-      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -2100,6 +2476,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/has-property-descriptors": {
+      "version": "1.0.2",
+      "license": "MIT",
+      "dependencies": {
+        "es-define-property": "^1.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/has-symbols": {
@@ -2190,6 +2576,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-it-type": {
+      "version": "5.1.3",
+      "license": "MIT",
+      "dependencies": {
+        "globalthis": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/is-number": {
@@ -2379,6 +2775,31 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/minipass": {
+      "version": "4.2.8",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/minizlib": {
+      "version": "3.1.0",
+      "license": "MIT",
+      "dependencies": {
+        "minipass": "^7.1.2"
+      },
+      "engines": {
+        "node": ">= 18"
+      }
+    },
+    "node_modules/minizlib/node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
     "node_modules/ms": {
       "version": "2.1.3",
       "license": "MIT"
@@ -2426,6 +2847,13 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/object-keys": {
+      "version": "1.1.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/obug": {
@@ -2838,6 +3266,13 @@
         "url": "https://github.com/steveukx/git-js?sponsor=1"
       }
     },
+    "node_modules/simple-invariant": {
+      "version": "2.0.1",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "dev": true,
@@ -2872,6 +3307,29 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/tar": {
+      "version": "7.5.19",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.19.tgz",
+      "integrity": "sha512-4LeEWl96twnS2Q7Bz4MGqgazLqO+hJN63GZxXoIqh1T3VweYD997gbU1ItNsQafqqXTXd5WFyFdReLtwvRBNiw==",
+      "license": "BlueOak-1.0.0",
+      "dependencies": {
+        "@isaacs/fs-minipass": "^4.0.0",
+        "chownr": "^3.0.0",
+        "minipass": "^7.1.2",
+        "minizlib": "^3.1.0",
+        "yallist": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tar/node_modules/minipass": {
+      "version": "7.1.3",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
       }
     },
     "node_modules/tinybench": {
@@ -2934,6 +3392,13 @@
       "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/tsx": {
       "version": "4.21.0",
@@ -3678,6 +4143,13 @@
       "version": "1.0.2",
       "license": "ISC"
     },
+    "node_modules/yallist": {
+      "version": "5.0.0",
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/yaml": {
       "version": "2.9.0",
       "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.9.0.tgz",
@@ -3693,8 +4165,22 @@
         "url": "https://github.com/sponsors/eemeli"
       }
     },
+    "node_modules/yauzl-promise": {
+      "version": "4.0.0",
+      "license": "MIT",
+      "dependencies": {
+        "@node-rs/crc32": "^1.7.0",
+        "is-it-type": "^5.1.2",
+        "simple-invariant": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/zod": {
-      "version": "4.3.6",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/zod/-/zod-4.4.3.tgz",
+      "integrity": "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==",
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@skilljack/mcp",
-  "version": "0.11.0",
+  "version": "0.12.0",
   "description": "MCP server that discovers and serves Agent Skills. I know kung fu.",
   "type": "module",
   "main": "dist/index.js",
@@ -60,12 +60,15 @@
     "@modelcontextprotocol/sdk": "^1.29.0",
     "chokidar": "^5.0.0",
     "simple-git": "^3.27.0",
+    "tar": "^7.4.0",
     "yaml": "^2.7.0",
+    "yauzl-promise": "^4.0.0",
     "zod": "^4.0.0"
   },
   "devDependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.114",
     "@types/node": "^22.10.0",
+    "@types/tar": "^6.1.13",
     "@vitest/coverage-v8": "^4.1.0",
     "cross-env": "^7.0.3",
     "tsx": "^4.19.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,11 +6,12 @@
  * Provides global skills with tools for progressive disclosure.
  *
  * Usage:
- *   skilljack-mcp /path/to/skills [/path2 ...]           # Local directories
- *   skilljack-mcp --static /path/to/skills               # Static mode (no file watching)
- *   skilljack-mcp github.com/owner/repo                  # GitHub repository
- *   skilljack-mcp /local github.com/owner/repo           # Mixed local + GitHub
- *   SKILLS_DIR=/path,github.com/owner/repo skilljack-mcp # Via environment
+ *   skilljack-mcp /path/to/skills [/path2 ...]                       # Local directories
+ *   skilljack-mcp --static /path/to/skills                           # Static mode (no file watching)
+ *   skilljack-mcp github.com/owner/repo                              # GitHub repository
+ *   skilljack-mcp https://example.com/.well-known/agent-skills/      # Well-known publisher
+ *   skilljack-mcp /local github.com/o/r https://ex.com               # Mixed sources
+ *   SKILLS_DIR=/path,github.com/owner/repo skilljack-mcp             # Via environment
  *   SKILLJACK_STATIC=true skilljack-mcp                  # Static mode via env
  *   (or configure local directories via the skill-config UI)
  *
@@ -49,6 +50,24 @@ import {
 } from "./github-config.js";
 import { syncAllRepos, SyncOptions } from "./github-sync.js";
 import { createPollingManager, PollingManager } from "./github-polling.js";
+import {
+  isWellKnownUrl,
+  parseWellKnownUrl,
+  isOriginAllowed,
+  getWellKnownConfig,
+  getWellKnownCachePath,
+  getWellKnownDisplayName,
+  getWellKnownPrefix,
+  WellKnownSpec,
+} from "./well-known-config.js";
+import {
+  syncAllWellKnown,
+  SyncOptions as WellKnownSyncOptions,
+} from "./well-known-sync.js";
+import {
+  createWellKnownPollingManager,
+  PollingManager as WellKnownPollingManager,
+} from "./well-known-polling.js";
 
 /**
  * Subdirectories to check for skills within the configured directory.
@@ -80,12 +99,16 @@ interface DirectorySourceMap {
  * @param localDirs - Local skill directories
  * @param githubSpecs - GitHub repository specifications
  * @param cacheDir - GitHub cache directory path
+ * @param wellKnownSpecs - Well-known publisher specifications
+ * @param wellKnownCacheDir - Well-known cache directory path
  * @param bundledDir - Optional bundled skills directory
  */
 function buildDirectorySourceMap(
   localDirs: string[],
   githubSpecs: GitHubRepoSpec[],
   cacheDir: string,
+  wellKnownSpecs: WellKnownSpec[],
+  wellKnownCacheDir: string,
   bundledDir?: string
 ): DirectorySourceMap {
   const map: DirectorySourceMap = {};
@@ -121,6 +144,22 @@ function buildDirectorySourceMap(
     }
   }
 
+  // Map well-known publisher cache directories. The skills root used at
+  // discovery time is `<cachePath>/skills`, and each skill lives in its own
+  // subdirectory. Mark the skills root so discoverSkills() picks them up.
+  for (const spec of wellKnownSpecs) {
+    const cachePath = getWellKnownCachePath(spec, wellKnownCacheDir);
+    const skillsRoot = path.join(cachePath, "skills");
+    const source: SkillSource = {
+      type: "well-known",
+      displayName: getWellKnownDisplayName(spec),
+      prefix: getWellKnownPrefix(spec),
+      origin: spec.origin,
+    };
+    map[skillsRoot] = source;
+    map[cachePath] = source;
+  }
+
   // Map bundled skills directory
   if (bundledDir) {
     map[bundledDir] = BUNDLED_SKILL_SOURCE;
@@ -143,6 +182,11 @@ let currentSkillsDirs: string[] = [];
  * GitHub specs that are currently being polled.
  */
 let currentGithubSpecs: GitHubRepoSpec[] = [];
+
+/**
+ * Well-known publisher specs that are currently being polled.
+ */
+let currentWellKnownSpecs: WellKnownSpec[] = [];
 
 /**
  * Current directory-to-source map for skill discovery.
@@ -174,15 +218,18 @@ export function getStaticMode(): boolean {
 }
 
 /**
- * Classify paths as local directories or GitHub repositories.
- * GitHub URLs are detected by checking for "github.com" in the path.
+ * Classify paths as local directories, GitHub repositories, or well-known
+ * publishers. Detection order: GitHub URL → well-known URL → local path.
  */
 export function classifyPaths(paths: string[]): {
   localDirs: string[];
   githubSpecs: GitHubRepoSpec[];
+  wellKnownSpecs: WellKnownSpec[];
 } {
   const localDirs: string[] = [];
   const githubSpecs: GitHubRepoSpec[] = [];
+  const wellKnownSpecs: WellKnownSpec[] = [];
+  const wkConfig = getWellKnownConfig();
 
   for (const p of paths) {
     if (isGitHubUrl(p)) {
@@ -191,6 +238,13 @@ export function classifyPaths(paths: string[]): {
         githubSpecs.push(spec);
       } catch (error) {
         console.error(`Warning: Invalid GitHub URL "${p}": ${error}`);
+      }
+    } else if (isWellKnownUrl(p)) {
+      try {
+        const spec = parseWellKnownUrl(p, wkConfig.allowHttp);
+        wellKnownSpecs.push(spec);
+      } catch (error) {
+        console.error(`Warning: Invalid well-known URL "${p}": ${error}`);
       }
     } else {
       // Local directory - resolve the path
@@ -212,7 +266,20 @@ export function classifyPaths(paths: string[]): {
     return true;
   });
 
-  return { localDirs: uniqueLocalDirs, githubSpecs: uniqueGithubSpecs };
+  // Deduplicate well-known specs by origin + basePath
+  const seenWk = new Set<string>();
+  const uniqueWellKnownSpecs = wellKnownSpecs.filter((spec) => {
+    const key = `${spec.origin}${spec.basePath}`;
+    if (seenWk.has(key)) return false;
+    seenWk.add(key);
+    return true;
+  });
+
+  return {
+    localDirs: uniqueLocalDirs,
+    githubSpecs: uniqueGithubSpecs,
+    wellKnownSpecs: uniqueWellKnownSpecs,
+  };
 }
 
 /**
@@ -466,11 +533,14 @@ async function main() {
   // This returns paths that may include GitHub URLs
   const allPaths = getActiveDirectories();
 
-  // Classify paths as local or GitHub
-  const { localDirs, githubSpecs } = classifyPaths(allPaths);
+  // Classify paths as local, GitHub, or well-known
+  const { localDirs, githubSpecs, wellKnownSpecs } = classifyPaths(allPaths);
 
   // Get GitHub configuration
   const githubConfig = getGitHubConfig();
+
+  // Get well-known configuration
+  const wellKnownConfig = getWellKnownConfig();
 
   // Sync GitHub repositories
   let githubDirs: string[] = [];
@@ -512,19 +582,68 @@ async function main() {
     }
   }
 
+  // Sync well-known publishers
+  let wellKnownDirs: string[] = [];
+
+  if (wellKnownSpecs.length > 0) {
+    console.error(
+      `Well-known publishers: ${wellKnownSpecs.map((s) => getWellKnownDisplayName(s)).join(", ")}`
+    );
+
+    for (const spec of wellKnownSpecs) {
+      if (!isOriginAllowed(spec, wellKnownConfig)) {
+        console.error(
+          `Blocked: ${spec.origin} not in allowed origins. ` +
+            `Set WELL_KNOWN_ALLOWED_ORIGINS or wellKnownAllowedOrigins in config to permit.`
+        );
+        continue;
+      }
+      currentWellKnownSpecs.push(spec);
+    }
+
+    if (currentWellKnownSpecs.length > 0) {
+      console.error(`Syncing ${currentWellKnownSpecs.length} well-known publisher(s)...`);
+
+      const wkSyncOptions: WellKnownSyncOptions = {
+        cacheDir: wellKnownConfig.cacheDir,
+        maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
+        maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
+      };
+
+      const wkResults = await syncAllWellKnown(currentWellKnownSpecs, wkSyncOptions);
+
+      for (const result of wkResults) {
+        if (!result.error) {
+          wellKnownDirs.push(result.localPath);
+        }
+      }
+
+      console.error(
+        `Successfully synced ${wellKnownDirs.length}/${currentWellKnownSpecs.length} publisher(s)`
+      );
+    }
+  }
+
   // Get bundled skills directory (ships with the package)
   const bundledSkillsDir = getBundledSkillsDir();
   const hasBundledSkills = fs.existsSync(bundledSkillsDir);
 
   // Combine all skill directories
   // User directories come first so they can override bundled skills (first-wins deduplication)
-  currentSkillsDirs = [...localDirs, ...githubDirs, ...(hasBundledSkills ? [bundledSkillsDir] : [])];
+  currentSkillsDirs = [
+    ...localDirs,
+    ...githubDirs,
+    ...wellKnownDirs,
+    ...(hasBundledSkills ? [bundledSkillsDir] : []),
+  ];
 
   // Build source map for skill discovery
   currentSourceMap = buildDirectorySourceMap(
     localDirs,
     currentGithubSpecs,
     githubConfig.cacheDir,
+    currentWellKnownSpecs,
+    wellKnownConfig.cacheDir,
     hasBundledSkills ? bundledSkillsDir : undefined
   );
 
@@ -534,6 +653,9 @@ async function main() {
   }
   if (githubDirs.length > 0) {
     console.error(`GitHub cache directories: ${githubDirs.join(", ")}`);
+  }
+  if (wellKnownDirs.length > 0) {
+    console.error(`Well-known cache directories: ${wellKnownDirs.join(", ")}`);
   }
   if (hasBundledSkills) {
     console.error(`Bundled skills: ${bundledSkillsDir}`);
@@ -597,13 +719,18 @@ async function main() {
   // Skip in static mode since skills list is frozen
   if (!isStatic) {
     registerSkillConfigTool(server, skillState, async () => {
-      // Callback when directories or GitHub settings change via UI
-      // Reload directories from config and refresh skills
+      // Callback when directories or remote-source settings change via UI.
+      // Reload directories from config and refresh skills.
       const newPaths = getActiveDirectories();
-      const { localDirs: newLocalDirs, githubSpecs: newGithubSpecs } = classifyPaths(newPaths);
+      const {
+        localDirs: newLocalDirs,
+        githubSpecs: newGithubSpecs,
+        wellKnownSpecs: newWellKnownSpecs,
+      } = classifyPaths(newPaths);
 
-      // Get fresh GitHub config (in case allowed orgs/users changed)
+      // Get fresh configs (in case allowlists changed)
       const freshGithubConfig = getGitHubConfig();
+      const freshWellKnownConfig = getWellKnownConfig();
 
       // Filter GitHub specs by allowlist and sync
       const allowedGithubSpecs: GitHubRepoSpec[] = [];
@@ -615,7 +742,6 @@ async function main() {
         }
       }
 
-      // Sync any GitHub repos
       let newGithubDirs: string[] = [];
       if (allowedGithubSpecs.length > 0) {
         console.error(`Syncing ${allowedGithubSpecs.length} GitHub repo(s)...`);
@@ -633,15 +759,53 @@ async function main() {
         console.error(`Successfully synced ${newGithubDirs.length}/${allowedGithubSpecs.length} repo(s)`);
       }
 
+      // Filter well-known specs by allowlist and sync
+      const allowedWellKnownSpecs: WellKnownSpec[] = [];
+      for (const spec of newWellKnownSpecs) {
+        if (isOriginAllowed(spec, freshWellKnownConfig)) {
+          allowedWellKnownSpecs.push(spec);
+        } else {
+          console.error(`Blocked: ${spec.origin} not in allowed origins.`);
+        }
+      }
+
+      let newWellKnownDirs: string[] = [];
+      if (allowedWellKnownSpecs.length > 0) {
+        console.error(`Syncing ${allowedWellKnownSpecs.length} well-known publisher(s)...`);
+        const wkSyncOptions: WellKnownSyncOptions = {
+          cacheDir: freshWellKnownConfig.cacheDir,
+          maxArtifactBytes: freshWellKnownConfig.maxArtifactBytes,
+          maxUnpackedBytes: freshWellKnownConfig.maxUnpackedBytes,
+        };
+        const wkResults = await syncAllWellKnown(allowedWellKnownSpecs, wkSyncOptions);
+        for (const result of wkResults) {
+          if (!result.error) {
+            newWellKnownDirs.push(result.localPath);
+          }
+        }
+        console.error(
+          `Successfully synced ${newWellKnownDirs.length}/${allowedWellKnownSpecs.length} publisher(s)`
+        );
+      }
+
       // Update current state
       currentGithubSpecs = allowedGithubSpecs;
+      currentWellKnownSpecs = allowedWellKnownSpecs;
       githubDirs = newGithubDirs;
+      wellKnownDirs = newWellKnownDirs;
       // Include bundled skills (last, so user skills take precedence)
-      currentSkillsDirs = [...newLocalDirs, ...newGithubDirs, ...(hasBundledSkills ? [bundledSkillsDir] : [])];
+      currentSkillsDirs = [
+        ...newLocalDirs,
+        ...newGithubDirs,
+        ...newWellKnownDirs,
+        ...(hasBundledSkills ? [bundledSkillsDir] : []),
+      ];
       currentSourceMap = buildDirectorySourceMap(
         newLocalDirs,
         allowedGithubSpecs,
         freshGithubConfig.cacheDir,
+        allowedWellKnownSpecs,
+        freshWellKnownConfig.cacheDir,
         hasBundledSkills ? bundledSkillsDir : undefined
       );
 
@@ -684,6 +848,37 @@ async function main() {
     });
 
     pollingManager.start();
+  }
+
+  // Set up well-known polling for updates (skip in static mode)
+  let wellKnownPollingManager: WellKnownPollingManager | null = null;
+  if (
+    !isStatic &&
+    currentWellKnownSpecs.length > 0 &&
+    wellKnownConfig.pollIntervalMs > 0
+  ) {
+    const wkSyncOptions: WellKnownSyncOptions = {
+      cacheDir: wellKnownConfig.cacheDir,
+      maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
+      maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
+    };
+
+    wellKnownPollingManager = createWellKnownPollingManager(
+      currentWellKnownSpecs,
+      wkSyncOptions,
+      {
+        intervalMs: wellKnownConfig.pollIntervalMs,
+        onUpdate: (spec, _result) => {
+          console.error(`Well-known update detected for ${spec.origin}`);
+          refreshSkills(currentSkillsDirs, server, skillTool, promptRegistry, subscriptionManager);
+        },
+        onError: (spec, error) => {
+          console.error(`Well-known polling error for ${spec.origin}: ${error.message}`);
+        },
+      }
+    );
+
+    wellKnownPollingManager.start();
   }
 
   // Connect via stdio transport

--- a/src/index.ts
+++ b/src/index.ts
@@ -608,6 +608,8 @@ async function main() {
         cacheDir: wellKnownConfig.cacheDir,
         maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
         maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
+        allowedOrigins: wellKnownConfig.allowedOrigins,
+        allowHttp: wellKnownConfig.allowHttp,
       };
 
       const wkResults = await syncAllWellKnown(currentWellKnownSpecs, wkSyncOptions);
@@ -776,6 +778,8 @@ async function main() {
           cacheDir: freshWellKnownConfig.cacheDir,
           maxArtifactBytes: freshWellKnownConfig.maxArtifactBytes,
           maxUnpackedBytes: freshWellKnownConfig.maxUnpackedBytes,
+          allowedOrigins: freshWellKnownConfig.allowedOrigins,
+          allowHttp: freshWellKnownConfig.allowHttp,
         };
         const wkResults = await syncAllWellKnown(allowedWellKnownSpecs, wkSyncOptions);
         for (const result of wkResults) {
@@ -861,6 +865,8 @@ async function main() {
       cacheDir: wellKnownConfig.cacheDir,
       maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
       maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
+      allowedOrigins: wellKnownConfig.allowedOrigins,
+      allowHttp: wellKnownConfig.allowHttp,
     };
 
     wellKnownPollingManager = createWellKnownPollingManager(

--- a/src/skill-config-tool.ts
+++ b/src/skill-config-tool.ts
@@ -28,11 +28,15 @@ import {
   getGitHubAllowedUsers,
   addGitHubAllowedOrg,
   removeGitHubAllowedOrg,
+  getWellKnownAllowedOrigins,
+  addWellKnownAllowedOrigin,
+  removeWellKnownAllowedOrigin,
   getStaticModeFromConfig,
   setStaticModeInConfig,
 } from "./skill-config.js";
 import { SkillState } from "./skill-tool.js";
 import { isGitHubUrl, parseGitHubUrl } from "./github-config.js";
+import { isWellKnownUrl, parseWellKnownUrl, getWellKnownConfig } from "./well-known-config.js";
 
 /**
  * Resource URI for the skill-config UI.
@@ -121,6 +125,21 @@ export function registerSkillConfigTool(
         } catch {
           // Invalid GitHub URL, count stays 0
         }
+      } else if (isWellKnownUrl(dir.path)) {
+        // For well-known directories, match by origin from skill source
+        try {
+          const spec = parseWellKnownUrl(dir.path, getWellKnownConfig().allowHttp);
+          for (const skill of skillState.skillMap.values()) {
+            if (
+              skill.source.type === "well-known" &&
+              skill.source.origin?.toLowerCase() === spec.origin.toLowerCase()
+            ) {
+              count++;
+            }
+          }
+        } catch {
+          // Invalid well-known URL, count stays 0
+        }
       } else {
         // For local directories, match by path prefix
         for (const skill of skillState.skillMap.values()) {
@@ -161,6 +180,7 @@ export function registerSkillConfigTool(
         staticMode: z.boolean(),
         allowedOrgs: z.array(z.string()),
         allowedUsers: z.array(z.string()),
+        allowedOrigins: z.array(z.string()),
       },
       _meta: { ui: { resourceUri: RESOURCE_URI } },
       annotations: {
@@ -188,6 +208,7 @@ export function registerSkillConfigTool(
           staticMode: getStaticModeFromConfig(),
           allowedOrgs: getGitHubAllowedOrgs(),
           allowedUsers: getGitHubAllowedUsers(),
+          allowedOrigins: getWellKnownAllowedOrigins(),
         },
       };
     }
@@ -251,6 +272,7 @@ export function registerSkillConfigTool(
             staticMode: getStaticModeFromConfig(),
             allowedOrgs: getGitHubAllowedOrgs(),
             allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
           },
         };
       } catch (error) {
@@ -330,6 +352,7 @@ export function registerSkillConfigTool(
             staticMode: getStaticModeFromConfig(),
             allowedOrgs: getGitHubAllowedOrgs(),
             allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
           },
         };
       } catch (error) {
@@ -403,6 +426,7 @@ export function registerSkillConfigTool(
             staticMode: getStaticModeFromConfig(),
             allowedOrgs: getGitHubAllowedOrgs(),
             allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
           },
         };
       } catch (error) {
@@ -477,6 +501,7 @@ export function registerSkillConfigTool(
             staticMode: getStaticModeFromConfig(),
             allowedOrgs: getGitHubAllowedOrgs(),
             allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
           },
         };
       } catch (error) {
@@ -491,6 +516,159 @@ export function registerSkillConfigTool(
           structuredContent: {
             success: false,
             allowedOrgs: getGitHubAllowedOrgs(),
+            error: message,
+          },
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Add allowed well-known origin tool (UI-only)
+  registerAppTool(
+    server,
+    "skill-config-add-allowed-origin",
+    {
+      title: "Add Allowed Well-Known Origin",
+      description:
+        "Add an HTTPS origin (e.g. https://example.com) to the allowed list for well-known publishers.",
+      inputSchema: {
+        origin: z
+          .string()
+          .describe(
+            "Origin or full URL (e.g. https://example.com or https://example.com/.well-known/agent-skills/). Only the scheme + host[:port] is stored."
+          ),
+      },
+      outputSchema: {
+        success: z.boolean(),
+        allowedOrigins: z.array(z.string()),
+        error: z.string().optional(),
+      },
+      _meta: {
+        ui: {
+          resourceUri: RESOURCE_URI,
+          visibility: ["app"],
+        },
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: false,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args): Promise<CallToolResult> => {
+      const { origin: rawInput } = args as { origin: string };
+
+      try {
+        // Normalize: accept full URLs and reduce to origin only.
+        let normalizedOrigin: string;
+        try {
+          normalizedOrigin = new URL(rawInput).origin;
+        } catch {
+          throw new Error(
+            `Invalid origin: "${rawInput}". Use the form https://example.com[:port].`
+          );
+        }
+        if (
+          !normalizedOrigin.startsWith("https://") &&
+          !(normalizedOrigin.startsWith("http://") && getWellKnownConfig().allowHttp)
+        ) {
+          throw new Error(
+            `Origin must use https:// (or http:// with WELL_KNOWN_ALLOW_HTTP=1 for local dev).`
+          );
+        }
+
+        addWellKnownAllowedOrigin(normalizedOrigin);
+        await onDirectoriesChanged(); // Trigger well-known resync
+
+        const directories = getDirectoriesWithCounts();
+        return {
+          content: [
+            { type: "text", text: `Added allowed origin: ${normalizedOrigin}` },
+          ],
+          structuredContent: {
+            success: true,
+            directories,
+            activeSource: getConfigState().activeSource,
+            isOverridden: getConfigState().isOverridden,
+            staticMode: getStaticModeFromConfig(),
+            allowedOrgs: getGitHubAllowedOrgs(),
+            allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Failed to add allowed origin: ${message}` }],
+          structuredContent: {
+            success: false,
+            allowedOrigins: getWellKnownAllowedOrigins(),
+            error: message,
+          },
+          isError: true,
+        };
+      }
+    }
+  );
+
+  // Remove allowed well-known origin tool (UI-only)
+  registerAppTool(
+    server,
+    "skill-config-remove-allowed-origin",
+    {
+      title: "Remove Allowed Well-Known Origin",
+      description: "Remove an HTTPS origin from the well-known allowed list.",
+      inputSchema: {
+        origin: z.string().describe("Origin to remove (exact match)"),
+      },
+      outputSchema: {
+        success: z.boolean(),
+        allowedOrigins: z.array(z.string()),
+        error: z.string().optional(),
+      },
+      _meta: {
+        ui: {
+          resourceUri: RESOURCE_URI,
+          visibility: ["app"],
+        },
+      },
+      annotations: {
+        readOnlyHint: false,
+        destructiveHint: true,
+        idempotentHint: true,
+        openWorldHint: false,
+      },
+    },
+    async (args): Promise<CallToolResult> => {
+      const { origin } = args as { origin: string };
+
+      try {
+        removeWellKnownAllowedOrigin(origin);
+        await onDirectoriesChanged(); // Trigger well-known resync
+
+        const directories = getDirectoriesWithCounts();
+        return {
+          content: [{ type: "text", text: `Removed allowed origin: ${origin}` }],
+          structuredContent: {
+            success: true,
+            directories,
+            activeSource: getConfigState().activeSource,
+            isOverridden: getConfigState().isOverridden,
+            staticMode: getStaticModeFromConfig(),
+            allowedOrgs: getGitHubAllowedOrgs(),
+            allowedUsers: getGitHubAllowedUsers(),
+            allowedOrigins: getWellKnownAllowedOrigins(),
+          },
+        };
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        return {
+          content: [{ type: "text", text: `Failed to remove allowed origin: ${message}` }],
+          structuredContent: {
+            success: false,
+            allowedOrigins: getWellKnownAllowedOrigins(),
             error: message,
           },
           isError: true,

--- a/src/skill-config.ts
+++ b/src/skill-config.ts
@@ -13,6 +13,12 @@ import * as fs from "node:fs";
 import * as path from "node:path";
 import * as os from "node:os";
 import { isGitHubUrl, parseGitHubUrl, isRepoAllowed, getGitHubConfig } from "./github-config.js";
+import {
+  isWellKnownUrl,
+  parseWellKnownUrl,
+  isOriginAllowed,
+  getWellKnownConfig,
+} from "./well-known-config.js";
 
 /**
  * Invocation settings that can be overridden per skill.
@@ -31,6 +37,7 @@ export interface SkillConfig {
   skillInvocationOverrides?: Record<string, SkillInvocationOverrides>;
   githubAllowedOrgs?: string[];
   githubAllowedUsers?: string[];
+  wellKnownAllowedOrigins?: string[];
 }
 
 /**
@@ -39,9 +46,9 @@ export interface SkillConfig {
 export type DirectorySource = "cli" | "env" | "config";
 
 /**
- * Type of skill source (local directory or GitHub repo).
+ * Type of skill source (local directory, GitHub repo, or well-known publisher).
  */
-export type SourceType = "local" | "github";
+export type SourceType = "local" | "github" | "well-known";
 
 /**
  * A skill directory with its source information.
@@ -56,11 +63,14 @@ export interface DirectoryInfo {
 }
 
 /**
- * Check if a path is valid (exists for local, always valid for GitHub).
+ * Check if a path is valid (exists for local, always valid for remote sources).
  */
 function isValidPath(p: string): boolean {
   if (isGitHubUrl(p)) {
     return true; // GitHub URLs are validated during sync
+  }
+  if (isWellKnownUrl(p)) {
+    return true; // Well-known URLs are validated during sync
   }
   return fs.existsSync(p);
 }
@@ -69,24 +79,45 @@ function isValidPath(p: string): boolean {
  * Get the source type for a path.
  */
 function getSourceType(p: string): SourceType {
-  return isGitHubUrl(p) ? "github" : "local";
+  if (isGitHubUrl(p)) return "github";
+  if (isWellKnownUrl(p)) return "well-known";
+  return "local";
 }
 
 /**
- * Check if a path is allowed (local paths are always allowed,
- * GitHub URLs must have their org/user in the allowlist).
+ * Check if a path is allowed.
+ *   - Local paths: always allowed.
+ *   - GitHub URLs: org/user must be in the GitHub allowlist.
+ *   - Well-known URLs: origin must be in the well-known allowlist.
  */
 function isPathAllowed(p: string): boolean {
-  if (!isGitHubUrl(p)) {
-    return true; // Local paths are always allowed
+  if (isGitHubUrl(p)) {
+    try {
+      const spec = parseGitHubUrl(p);
+      const config = getGitHubConfig();
+      return isRepoAllowed(spec, config);
+    } catch {
+      return false;
+    }
   }
-  try {
-    const spec = parseGitHubUrl(p);
-    const config = getGitHubConfig();
-    return isRepoAllowed(spec, config);
-  } catch {
-    return false; // Invalid GitHub URL
+  if (isWellKnownUrl(p)) {
+    try {
+      const config = getWellKnownConfig();
+      const spec = parseWellKnownUrl(p, config.allowHttp);
+      return isOriginAllowed(spec, config);
+    } catch {
+      return false;
+    }
   }
+  return true; // Local paths
+}
+
+/**
+ * True iff `p` is a remote URL (GitHub or well-known) that should be passed
+ * through unchanged rather than resolved as a local path.
+ */
+function isRemoteUrl(p: string): boolean {
+  return isGitHubUrl(p) || isWellKnownUrl(p);
 }
 
 /**
@@ -150,7 +181,7 @@ export function loadConfigFile(): SkillConfig {
     const skillDirectories = Array.isArray(parsed.skillDirectories)
       ? parsed.skillDirectories
           .filter((p: unknown) => typeof p === "string")
-          .map((p: string) => isGitHubUrl(p) ? p : path.resolve(p))
+          .map((p: string) => isRemoteUrl(p) ? p : path.resolve(p))
       : [];
 
     // Validate and normalize invocation overrides
@@ -175,6 +206,9 @@ export function loadConfigFile(): SkillConfig {
       staticMode: parsed.staticMode === true,
       githubAllowedOrgs: Array.isArray(parsed.githubAllowedOrgs) ? parsed.githubAllowedOrgs : [],
       githubAllowedUsers: Array.isArray(parsed.githubAllowedUsers) ? parsed.githubAllowedUsers : [],
+      wellKnownAllowedOrigins: Array.isArray(parsed.wellKnownAllowedOrigins)
+        ? parsed.wellKnownAllowedOrigins.filter((o: unknown): o is string => typeof o === "string")
+        : [],
     };
   } catch (error) {
     console.error(`Warning: Failed to parse config file: ${error}`);
@@ -210,7 +244,7 @@ export function parseCLIArgs(): string[] {
         .split(PATH_LIST_SEPARATOR)
         .map((p) => p.trim())
         .filter((p) => p.length > 0)
-        .map((p) => isGitHubUrl(p) ? p : path.resolve(p));
+        .map((p) => isRemoteUrl(p) ? p : path.resolve(p));
       dirs.push(...paths);
     }
   }
@@ -232,7 +266,7 @@ export function parseEnvVar(): string[] {
     .split(PATH_LIST_SEPARATOR)
     .map((p) => p.trim())
     .filter((p) => p.length > 0)
-    .map((p) => isGitHubUrl(p) ? p : path.resolve(p));
+    .map((p) => isRemoteUrl(p) ? p : path.resolve(p));
 
   return [...new Set(dirs)]; // Deduplicate
 }
@@ -354,11 +388,11 @@ export function getAllDirectoriesWithSources(): DirectoryInfo[] {
  * Does not affect CLI or env var configurations.
  */
 export function addDirectoryToConfig(directory: string): void {
-  // For GitHub URLs, store as-is; for local paths, resolve to absolute
-  const normalized = isGitHubUrl(directory) ? directory : path.resolve(directory);
+  // For remote URLs, store as-is; for local paths, resolve to absolute
+  const normalized = isRemoteUrl(directory) ? directory : path.resolve(directory);
 
   // Validate local directories exist
-  if (!isGitHubUrl(directory)) {
+  if (!isRemoteUrl(directory)) {
     if (!fs.existsSync(normalized)) {
       throw new Error(`Directory does not exist: ${normalized}`);
     }
@@ -384,8 +418,8 @@ export function addDirectoryToConfig(directory: string): void {
  * Only removes from config file, not CLI or env var.
  */
 export function removeDirectoryFromConfig(directory: string): void {
-  // For GitHub URLs, use as-is; for local paths, resolve to absolute
-  const normalized = isGitHubUrl(directory) ? directory : path.resolve(directory);
+  // For remote URLs, use as-is; for local paths, resolve to absolute
+  const normalized = isRemoteUrl(directory) ? directory : path.resolve(directory);
   const config = loadConfigFile();
 
   const index = config.skillDirectories.indexOf(normalized);
@@ -556,6 +590,46 @@ export function removeGitHubAllowedUser(user: string): void {
   const normalized = user.toLowerCase().trim();
   config.githubAllowedUsers = config.githubAllowedUsers.filter(
     (u) => u.toLowerCase() !== normalized
+  );
+  saveConfigFile(config);
+}
+
+/**
+ * Get the well-known allowed origins from the config file.
+ */
+export function getWellKnownAllowedOrigins(): string[] {
+  const config = loadConfigFile();
+  return config.wellKnownAllowedOrigins || [];
+}
+
+/**
+ * Add a well-known origin to the allowed list.
+ * @param origin - Origin string like "https://example.com"
+ */
+export function addWellKnownAllowedOrigin(origin: string): void {
+  const config = loadConfigFile();
+  if (!config.wellKnownAllowedOrigins) {
+    config.wellKnownAllowedOrigins = [];
+  }
+  const normalized = origin.toLowerCase().trim();
+  if (!config.wellKnownAllowedOrigins.some((o) => o.toLowerCase() === normalized)) {
+    config.wellKnownAllowedOrigins.push(origin.trim());
+    saveConfigFile(config);
+  }
+}
+
+/**
+ * Remove a well-known origin from the allowed list.
+ * @param origin - Origin string like "https://example.com"
+ */
+export function removeWellKnownAllowedOrigin(origin: string): void {
+  const config = loadConfigFile();
+  if (!config.wellKnownAllowedOrigins) {
+    return;
+  }
+  const normalized = origin.toLowerCase().trim();
+  config.wellKnownAllowedOrigins = config.wellKnownAllowedOrigins.filter(
+    (o) => o.toLowerCase() !== normalized
   );
   saveConfigFile(config);
 }

--- a/src/skill-discovery.ts
+++ b/src/skill-discovery.ts
@@ -15,11 +15,12 @@ import type { Annotations } from "@modelcontextprotocol/sdk/types.js";
  * Indicates whether the skill comes from a local directory or GitHub repository.
  */
 export interface SkillSource {
-  type: "local" | "github" | "bundled";
-  displayName: string; // "Local", "owner/repo", or "Bundled"
+  type: "local" | "github" | "bundled" | "well-known";
+  displayName: string; // "Local", "owner/repo", "Bundled", or "<origin><base-path>"
   prefix: string; // Namespace prefix for skill names (e.g., "my-project", "owner-repo", "" for bundled)
   owner?: string; // GitHub org/user (only for github type)
   repo?: string; // GitHub repo name (only for github type)
+  origin?: string; // Well-known origin (only for well-known type, e.g. "https://example.com")
 }
 
 /**

--- a/src/skill-display-tool.ts
+++ b/src/skill-display-tool.ts
@@ -88,7 +88,7 @@ interface SkillDisplayInfo {
   isAssistantOverridden: boolean;
   isUserOverridden: boolean;
   // Source information
-  sourceType: "local" | "github" | "bundled";
+  sourceType: "local" | "github" | "bundled" | "well-known";
   sourceDisplayName: string;
   sourceOwner?: string;
   sourceRepo?: string;
@@ -153,7 +153,7 @@ export function registerSkillDisplayTool(
           userInvocable: z.boolean(),
           isAssistantOverridden: z.boolean(),
           isUserOverridden: z.boolean(),
-          sourceType: z.enum(["local", "github", "bundled"]),
+          sourceType: z.enum(["local", "github", "bundled", "well-known"]),
           sourceDisplayName: z.string(),
           sourceOwner: z.string().optional(),
           sourceRepo: z.string().optional(),
@@ -205,7 +205,7 @@ export function registerSkillDisplayTool(
           userInvocable: z.boolean(),
           isAssistantOverridden: z.boolean(),
           isUserOverridden: z.boolean(),
-          sourceType: z.enum(["local", "github", "bundled"]),
+          sourceType: z.enum(["local", "github", "bundled", "well-known"]),
           sourceDisplayName: z.string(),
           sourceOwner: z.string().optional(),
           sourceRepo: z.string().optional(),
@@ -298,7 +298,7 @@ export function registerSkillDisplayTool(
           userInvocable: z.boolean(),
           isAssistantOverridden: z.boolean(),
           isUserOverridden: z.boolean(),
-          sourceType: z.enum(["local", "github", "bundled"]),
+          sourceType: z.enum(["local", "github", "bundled", "well-known"]),
           sourceDisplayName: z.string(),
           sourceOwner: z.string().optional(),
           sourceRepo: z.string().optional(),

--- a/src/types/yauzl-promise.d.ts
+++ b/src/types/yauzl-promise.d.ts
@@ -1,0 +1,44 @@
+/**
+ * Minimal ambient declarations for `yauzl-promise@4`.
+ * The package ships no types of its own; we only declare what this codebase
+ * uses (fromBuffer + async iteration + Entry.openReadStream + close).
+ */
+declare module "yauzl-promise" {
+  import { Readable } from "node:stream";
+
+  export interface Entry {
+    filename: string;
+    compressedSize: number;
+    uncompressedSize: number;
+    externalFileAttributes: number;
+    generalPurposeBitFlag: number;
+    compressionMethod: number;
+    openReadStream(options?: {
+      decompress?: boolean;
+      decrypt?: boolean;
+      validateCrc32?: boolean;
+      start?: number;
+      end?: number;
+    }): Promise<Readable>;
+    isEncrypted(): boolean;
+    isCompressed(): boolean;
+    getLastMod(): Date;
+  }
+
+  export interface ZipFile {
+    readEntry(): Promise<Entry | null>;
+    close(): Promise<void>;
+    [Symbol.asyncIterator](): AsyncIterableIterator<Entry>;
+  }
+
+  export interface OpenOptions {
+    decodeStrings?: boolean;
+    validateEntrySizes?: boolean;
+    validateFilenames?: boolean;
+    strictFilenames?: boolean;
+    supportMacArchive?: boolean;
+  }
+
+  export function fromBuffer(buffer: Buffer, options?: OpenOptions): Promise<ZipFile>;
+  export function open(path: string, options?: OpenOptions): Promise<ZipFile>;
+}

--- a/src/ui/mcp-app.css
+++ b/src/ui/mcp-app.css
@@ -314,7 +314,8 @@ h1 {
   font-family: 'Fira Code', 'Consolas', monospace;
 }
 
-.remove-org-btn {
+.remove-org-btn,
+.remove-origin-btn {
   padding: 2px 8px;
   background: transparent;
   color: var(--text-secondary);
@@ -324,7 +325,8 @@ h1 {
   cursor: pointer;
 }
 
-.remove-org-btn:hover {
+.remove-org-btn:hover,
+.remove-origin-btn:hover {
   background: var(--error);
   border-color: var(--error);
   color: white;

--- a/src/ui/mcp-app.html
+++ b/src/ui/mcp-app.html
@@ -140,15 +140,15 @@
       </div>
       <div class="modal-body">
         <div class="form-group">
-          <label for="directory-path">Directory Path or GitHub URL</label>
+          <label for="directory-path">Directory Path, GitHub URL, or Well-Known URL</label>
           <input
             type="text"
             id="directory-path"
-            placeholder="/path/to/skills or github.com/org/repo"
+            placeholder="/path, github.com/org/repo, or https://example.com/.well-known/agent-skills/"
           >
           <div class="form-hint">
-            Local path or GitHub URL to a directory containing skill folders (each with a SKILL.md file).
-            <br>Examples: <code>C:\skills</code>, <code>github.com/org/repo</code>, <code>github.com/org/repo/subdir</code>
+            Local path, GitHub repository, or HTTPS publisher serving <code>/.well-known/agent-skills/index.json</code>.
+            <br>Examples: <code>C:\skills</code>, <code>github.com/org/repo</code>, <code>github.com/org/repo/subdir</code>, <code>https://example.com/.well-known/agent-skills/</code>
           </div>
         </div>
       </div>

--- a/src/ui/mcp-app.html
+++ b/src/ui/mcp-app.html
@@ -50,6 +50,21 @@
     <div class="empty-state small">No allowed orgs configured. GitHub repos are blocked until an org/user is added.</div>
   </div>
 
+  <!-- Well-Known Allowed Origins Section -->
+  <div class="section-header">
+    <div>
+      <h2>Well-Known Allowed Origins</h2>
+      <div class="section-hint">HTTPS origins allowed to publish skills via <code>/.well-known/agent-skills/</code></div>
+    </div>
+    <button class="add-btn add-origin-btn" id="add-origin-btn">
+      <span>+</span> Add Origin
+    </button>
+  </div>
+
+  <div id="allowed-origins-list" class="allowed-list">
+    <div class="empty-state small">No allowed origins configured. Well-known publishers are blocked until an origin is added.</div>
+  </div>
+
   <!-- Settings Section -->
   <div class="settings-section">
     <h2>Settings</h2>
@@ -82,6 +97,53 @@
       <div class="modal-footer">
         <button class="btn btn-secondary" id="confirm-remove-org-cancel">Cancel</button>
         <button class="btn btn-danger" id="confirm-remove-org-btn">Remove</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Confirm Remove Origin Modal -->
+  <div class="modal-overlay" id="confirm-remove-origin-modal">
+    <div class="modal modal-small">
+      <div class="modal-header">
+        <h2>Remove Allowed Origin</h2>
+        <button class="modal-close" id="confirm-remove-origin-close">&times;</button>
+      </div>
+      <div class="modal-body">
+        <p>Remove this origin from the allowed list?</p>
+        <p class="confirm-path" id="confirm-remove-origin-name"></p>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" id="confirm-remove-origin-cancel">Cancel</button>
+        <button class="btn btn-danger" id="confirm-remove-origin-btn">Remove</button>
+      </div>
+    </div>
+  </div>
+
+  <!-- Add Origin Modal -->
+  <div class="modal-overlay" id="add-origin-modal">
+    <div class="modal">
+      <div class="modal-header">
+        <h2>Add Allowed Well-Known Origin</h2>
+        <button class="modal-close" data-modal="add-origin-modal">&times;</button>
+      </div>
+      <div class="modal-body">
+        <div class="form-group">
+          <label for="origin-name">Origin</label>
+          <input
+            type="text"
+            id="origin-name"
+            placeholder="https://example.com"
+          >
+          <div class="form-hint">
+            HTTPS origin (scheme + host + optional port) of a well-known publisher.
+            <br>You can paste a full URL — only the origin is stored.
+            <br>Examples: <code>https://example.com</code>, <code>https://skills.acme.org:8443</code>
+          </div>
+        </div>
+      </div>
+      <div class="modal-footer">
+        <button class="btn btn-secondary" data-modal="add-origin-modal">Cancel</button>
+        <button class="btn btn-primary" id="add-origin-submit-btn">Add Origin</button>
       </div>
     </div>
   </div>

--- a/src/ui/mcp-app.ts
+++ b/src/ui/mcp-app.ts
@@ -12,7 +12,7 @@ import {
 interface DirectoryInfo {
   path: string;
   source: "cli" | "env" | "config";
-  type: "local" | "github";
+  type: "local" | "github" | "well-known";
   valid: boolean;
   allowed: boolean;
   skillCount?: number;
@@ -173,7 +173,7 @@ function renderDirectories() {
   directoryList.innerHTML = directories
     .map((dir) => {
       const isReadOnly = dir.source !== "config";
-      const isBlocked = dir.type === "github" && !dir.allowed;
+      const isBlocked = (dir.type === "github" || dir.type === "well-known") && !dir.allowed;
       return `
       <div class="directory-card ${isReadOnly ? "readonly" : ""} ${isBlocked ? "blocked" : ""}">
         ${isReadOnly ? `<span class="lock-icon" title="Read-only: configured via ${dir.source.toUpperCase()}">&#128274;</span>` : ""}

--- a/src/ui/mcp-app.ts
+++ b/src/ui/mcp-app.ts
@@ -25,6 +25,7 @@ interface ConfigState {
   staticMode?: boolean;
   allowedOrgs?: string[];
   allowedUsers?: string[];
+  allowedOrigins?: string[];
   success?: boolean;
   error?: string;
 }
@@ -36,6 +37,7 @@ let isOverridden = false;
 let staticMode = false;
 let allowedOrgs: string[] = [];
 let allowedUsers: string[] = [];
+let allowedOrigins: string[] = [];
 let app: App | null = null;
 
 // DOM Elements
@@ -69,6 +71,7 @@ const confirmRemoveClose = document.getElementById("confirm-remove-close") as HT
 // Track pending removal
 let pendingRemovePath: string | null = null;
 let pendingRemoveOrg: string | null = null;
+let pendingRemoveOrigin: string | null = null;
 
 // Confirm remove org modal DOM elements
 const confirmRemoveOrgModal = document.getElementById("confirm-remove-org-modal")!;
@@ -76,6 +79,20 @@ const confirmRemoveOrgName = document.getElementById("confirm-remove-org-name")!
 const confirmRemoveOrgBtn = document.getElementById("confirm-remove-org-btn") as HTMLButtonElement;
 const confirmRemoveOrgCancel = document.getElementById("confirm-remove-org-cancel") as HTMLButtonElement;
 const confirmRemoveOrgClose = document.getElementById("confirm-remove-org-close") as HTMLButtonElement;
+
+// Allowed origins DOM elements
+const allowedOriginsList = document.getElementById("allowed-origins-list")!;
+const addOriginBtn = document.getElementById("add-origin-btn") as HTMLButtonElement;
+const addOriginModal = document.getElementById("add-origin-modal")!;
+const originNameInput = document.getElementById("origin-name") as HTMLInputElement;
+const addOriginSubmitBtn = document.getElementById("add-origin-submit-btn") as HTMLButtonElement;
+
+// Confirm remove origin modal DOM elements
+const confirmRemoveOriginModal = document.getElementById("confirm-remove-origin-modal")!;
+const confirmRemoveOriginName = document.getElementById("confirm-remove-origin-name")!;
+const confirmRemoveOriginBtn = document.getElementById("confirm-remove-origin-btn") as HTMLButtonElement;
+const confirmRemoveOriginCancel = document.getElementById("confirm-remove-origin-cancel") as HTMLButtonElement;
+const confirmRemoveOriginClose = document.getElementById("confirm-remove-origin-close") as HTMLButtonElement;
 
 // Handle host context changes
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -119,6 +136,9 @@ function updateState(data: ConfigState) {
   if (data.allowedUsers) {
     allowedUsers = data.allowedUsers;
   }
+  if (data.allowedOrigins) {
+    allowedOrigins = data.allowedOrigins;
+  }
 
   render();
 }
@@ -129,6 +149,7 @@ function render() {
   renderOverrideBanner();
   renderDirectories();
   renderAllowedOrgs();
+  renderAllowedOrigins();
   updateAddButton();
   renderStaticModeToggle();
 }
@@ -439,6 +460,118 @@ async function removeAllowedOrg(org: string) {
   }
 }
 
+// Render allowed origins list
+function renderAllowedOrigins() {
+  if (allowedOrigins.length === 0) {
+    allowedOriginsList.innerHTML = `
+      <div class="empty-state small">
+        No allowed origins configured. Well-known publishers are blocked until an origin is added.
+      </div>
+    `;
+    return;
+  }
+
+  allowedOriginsList.innerHTML = allowedOrigins
+    .map((origin) => `
+      <div class="allowed-item">
+        <span class="allowed-name">${escapeHtml(origin)}</span>
+        <button class="remove-origin-btn" data-origin="${escapeHtml(origin)}">Remove</button>
+      </div>
+    `)
+    .join("");
+
+  allowedOriginsList.querySelectorAll(".remove-origin-btn").forEach((btn) => {
+    btn.addEventListener("click", () => {
+      const origin = (btn as HTMLButtonElement).dataset.origin;
+      if (origin) {
+        showConfirmRemoveOriginModal(origin);
+      }
+    });
+  });
+}
+
+// Add allowed origin
+async function addAllowedOrigin() {
+  const origin = originNameInput.value.trim();
+  if (!origin) {
+    showToast("Please enter an origin", "error");
+    return;
+  }
+
+  addOriginSubmitBtn.disabled = true;
+  addOriginSubmitBtn.textContent = "Adding...";
+
+  try {
+    const result = await app!.callServerTool({
+      name: "skill-config-add-allowed-origin",
+      arguments: { origin },
+    });
+
+    console.log("Add origin result:", result);
+
+    const structured = result.structuredContent as unknown as ConfigState;
+    if (structured?.success) {
+      updateState(structured);
+      closeOriginModal();
+      showToast(`Added allowed origin`, "success");
+    } else {
+      showToast(structured?.error || "Failed to add origin", "error");
+    }
+  } catch (error) {
+    console.error("Add origin error:", error);
+    showToast((error as Error).message || "Failed to add origin", "error");
+  } finally {
+    addOriginSubmitBtn.disabled = false;
+    addOriginSubmitBtn.textContent = "Add Origin";
+  }
+}
+
+// Show confirmation modal for removing an allowed origin
+function showConfirmRemoveOriginModal(origin: string) {
+  pendingRemoveOrigin = origin;
+  confirmRemoveOriginName.textContent = origin;
+  confirmRemoveOriginModal.classList.add("active");
+}
+
+function closeConfirmRemoveOriginModal() {
+  confirmRemoveOriginModal.classList.remove("active");
+  pendingRemoveOrigin = null;
+}
+
+// Remove allowed origin (called after confirmation)
+async function removeAllowedOrigin(origin: string) {
+  try {
+    const result = await app!.callServerTool({
+      name: "skill-config-remove-allowed-origin",
+      arguments: { origin },
+    });
+
+    console.log("Remove origin result:", result);
+
+    const structured = result.structuredContent as unknown as ConfigState;
+    if (structured?.success) {
+      updateState(structured);
+      showToast(`Removed allowed origin: ${origin}`, "success");
+    } else {
+      showToast(structured?.error || "Failed to remove origin", "error");
+    }
+  } catch (error) {
+    console.error("Remove origin error:", error);
+    showToast((error as Error).message || "Failed to remove origin", "error");
+  }
+}
+
+// Origin modal functions
+function showOriginModal() {
+  originNameInput.value = "";
+  addOriginModal.classList.add("active");
+  originNameInput.focus();
+}
+
+function closeOriginModal() {
+  addOriginModal.classList.remove("active");
+}
+
 // Org modal functions
 function showOrgModal() {
   orgNameInput.value = "";
@@ -525,6 +658,28 @@ orgNameInput.addEventListener("keydown", (e) => {
     addAllowedOrg();
   }
 });
+
+// Origin modal event listeners
+addOriginBtn.addEventListener("click", showOriginModal);
+addOriginModal.querySelector(".modal-close")?.addEventListener("click", closeOriginModal);
+addOriginModal.querySelector(".btn-secondary")?.addEventListener("click", closeOriginModal);
+addOriginSubmitBtn.addEventListener("click", addAllowedOrigin);
+originNameInput.addEventListener("keydown", (e) => {
+  if (e.key === "Enter") {
+    addAllowedOrigin();
+  }
+});
+
+// Confirm remove origin modal event listeners
+confirmRemoveOriginBtn.addEventListener("click", async () => {
+  if (pendingRemoveOrigin) {
+    const origin = pendingRemoveOrigin;
+    closeConfirmRemoveOriginModal();
+    await removeAllowedOrigin(origin);
+  }
+});
+confirmRemoveOriginCancel.addEventListener("click", closeConfirmRemoveOriginModal);
+confirmRemoveOriginClose.addEventListener("click", closeConfirmRemoveOriginModal);
 
 // Static mode toggle event listener
 staticModeToggle?.addEventListener("change", (e) => {

--- a/src/ui/skill-display.css
+++ b/src/ui/skill-display.css
@@ -182,6 +182,11 @@ h1 {
   color: #fff;
 }
 
+.source-badge.well-known {
+  background: #0a7c5a;
+  color: #fff;
+}
+
 .source-icon {
   flex-shrink: 0;
 }

--- a/src/ui/skill-display.ts
+++ b/src/ui/skill-display.ts
@@ -18,7 +18,7 @@ interface SkillDisplayInfo {
   isAssistantOverridden: boolean;
   isUserOverridden: boolean;
   // Source information
-  sourceType: "local" | "github" | "bundled";
+  sourceType: "local" | "github" | "bundled" | "well-known";
   sourceDisplayName: string;
   sourceOwner?: string;
   sourceRepo?: string;
@@ -147,6 +147,13 @@ function renderSkills() {
                <path fill="currentColor" d="M8.878.392a1.75 1.75 0 0 0-1.756 0l-5.25 3.045A1.75 1.75 0 0 0 1 4.951v6.098c0 .624.332 1.2.872 1.514l5.25 3.045a1.75 1.75 0 0 0 1.756 0l5.25-3.045c.54-.313.872-.89.872-1.514V4.951c0-.624-.332-1.2-.872-1.514L8.878.392ZM8 3.5a.75.75 0 0 1 .75.75v3.75a.75.75 0 0 1-1.5 0V4.25A.75.75 0 0 1 8 3.5Zm0 8a1 1 0 1 1 0-2 1 1 0 0 1 0 2Z"/>
              </svg>
              Bundled
+           </span>`;
+      } else if (skill.sourceType === "well-known") {
+        sourceBadge = `<span class="source-badge well-known" title="From well-known publisher: ${escapeHtml(skill.sourceDisplayName)}">
+             <svg class="source-icon" viewBox="0 0 16 16" width="12" height="12" aria-hidden="true">
+               <path fill="currentColor" d="M8 0a8 8 0 100 16A8 8 0 008 0zM1.5 8a6.5 6.5 0 011.92-4.62 22.65 22.65 0 00-.71 2.78H1.62A6.46 6.46 0 011.5 8zm.7 1.66h.92c.13.95.33 1.83.6 2.6A6.51 6.51 0 012.2 9.66zm6.05 4.84a8.6 8.6 0 01-1.4-2.84h2.8a8.6 8.6 0 01-1.4 2.84zM6.45 10c-.18-.7-.32-1.47-.4-2.34h3.9c-.08.87-.22 1.64-.4 2.34zm-.4-3.66c.08-.87.22-1.64.4-2.34h3.1c.18.7.32 1.47.4 2.34zM5.55 1.5a8.6 8.6 0 011.4 2.84h-2.8a8.6 8.6 0 011.4-2.84zM3.12 4.34a6.51 6.51 0 011.52-2.6c-.27.77-.47 1.65-.6 2.6h-.92zm-.92 1.66h1c-.05.55-.07 1.11-.07 1.66s.02 1.11.07 1.66h-1A6.46 6.46 0 012.2 8c0-.7.07-1.36.2-2zm10.68 0a6.46 6.46 0 010 4h-1c.05-.55.07-1.11.07-1.66s-.02-1.11-.07-1.66h1zM12.88 4.34h-.92c-.13-.95-.33-1.83-.6-2.6a6.51 6.51 0 011.52 2.6zm-1.04 7.32a6.51 6.51 0 01-1.52 2.6c.27-.77.47-1.65.6-2.6h.92zM10.43 6h-.93c.06.55.08 1.11.08 1.66 0 .55-.02 1.11-.08 1.66h.93c.13-.65.2-1.31.2-1.66s-.07-1.01-.2-1.66z"/>
+             </svg>
+             ${escapeHtml(skill.sourceDisplayName)}
            </span>`;
       } else {
         sourceBadge = `<span class="source-badge local" title="Local skill directory">

--- a/src/well-known-config.test.ts
+++ b/src/well-known-config.test.ts
@@ -4,6 +4,7 @@ import {
   isWellKnownUrl,
   parseWellKnownUrl,
   isOriginAllowed,
+  assertUrlAllowed,
   getWellKnownCacheKey,
   getWellKnownCachePath,
   getWellKnownIndexUrl,
@@ -149,6 +150,46 @@ describe("isOriginAllowed", () => {
         config
       )
     ).toBe(false);
+  });
+});
+
+describe("assertUrlAllowed", () => {
+  const allowed = { allowedOrigins: ["https://example.com"], allowHttp: false };
+
+  it("accepts an https url whose origin is allowlisted", () => {
+    expect(() =>
+      assertUrlAllowed("https://example.com/skills/a/SKILL.md", allowed)
+    ).not.toThrow();
+  });
+
+  it("rejects an off-allowlist origin (SSRF / cross-origin artifact)", () => {
+    expect(() =>
+      assertUrlAllowed("https://169.254.169.254/latest/meta-data", allowed)
+    ).toThrow(/not in WELL_KNOWN_ALLOWED_ORIGINS/);
+    expect(() =>
+      assertUrlAllowed("https://cdn.example.com/a.tgz", allowed)
+    ).toThrow(/not in WELL_KNOWN_ALLOWED_ORIGINS/);
+  });
+
+  it("rejects http when allowHttp is false, even if origin matches", () => {
+    expect(() =>
+      assertUrlAllowed("http://example.com/a", allowed)
+    ).toThrow(/disallowed scheme/);
+  });
+
+  it("permits http only when allowHttp is set and origin matches", () => {
+    const cfg = { allowedOrigins: ["http://example.com"], allowHttp: true };
+    expect(() => assertUrlAllowed("http://example.com/a", cfg)).not.toThrow();
+    // still origin-gated
+    expect(() => assertUrlAllowed("http://evil.com/a", cfg)).toThrow(
+      /not in WELL_KNOWN_ALLOWED_ORIGINS/
+    );
+  });
+
+  it("rejects non-http(s) schemes (file:, etc.)", () => {
+    expect(() => assertUrlAllowed("file:///etc/passwd", allowed)).toThrow(
+      /disallowed scheme/
+    );
   });
 });
 

--- a/src/well-known-config.test.ts
+++ b/src/well-known-config.test.ts
@@ -1,0 +1,216 @@
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import {
+  isWellKnownUrl,
+  parseWellKnownUrl,
+  isOriginAllowed,
+  getWellKnownCacheKey,
+  getWellKnownCachePath,
+  getWellKnownIndexUrl,
+  resolveArtifactUrl,
+  WellKnownConfig,
+} from "./well-known-config.js";
+
+describe("isWellKnownUrl", () => {
+  it("returns true for https://example.com URL", () => {
+    expect(isWellKnownUrl("https://example.com")).toBe(true);
+    expect(isWellKnownUrl("https://example.com/.well-known/agent-skills/")).toBe(true);
+  });
+
+  it("returns false for github URLs", () => {
+    expect(isWellKnownUrl("https://github.com/owner/repo")).toBe(false);
+    expect(isWellKnownUrl("github.com/owner/repo")).toBe(false);
+  });
+
+  it("returns false for local paths", () => {
+    expect(isWellKnownUrl("/local/path")).toBe(false);
+    expect(isWellKnownUrl("C:\\Users\\project")).toBe(false);
+    expect(isWellKnownUrl("./relative")).toBe(false);
+  });
+
+  it("returns false for non-http schemes", () => {
+    expect(isWellKnownUrl("ftp://example.com")).toBe(false);
+    expect(isWellKnownUrl("file:///tmp/foo")).toBe(false);
+  });
+
+  it("returns true for http when present (parser still gates by allowHttp)", () => {
+    expect(isWellKnownUrl("http://example.com")).toBe(true);
+  });
+});
+
+describe("parseWellKnownUrl", () => {
+  it("auto-appends /.well-known/agent-skills when missing", () => {
+    const spec = parseWellKnownUrl("https://example.com");
+    expect(spec.origin).toBe("https://example.com");
+    expect(spec.basePath).toBe("/.well-known/agent-skills");
+  });
+
+  it("preserves existing /.well-known/agent-skills path", () => {
+    const spec = parseWellKnownUrl("https://example.com/.well-known/agent-skills");
+    expect(spec.basePath).toBe("/.well-known/agent-skills");
+  });
+
+  it("strips trailing /index.json", () => {
+    const spec = parseWellKnownUrl(
+      "https://example.com/.well-known/agent-skills/index.json"
+    );
+    expect(spec.basePath).toBe("/.well-known/agent-skills");
+  });
+
+  it("strips trailing slashes", () => {
+    const spec = parseWellKnownUrl("https://example.com/.well-known/agent-skills/");
+    expect(spec.basePath).toBe("/.well-known/agent-skills");
+  });
+
+  it("preserves a path prefix before /.well-known/agent-skills", () => {
+    const spec = parseWellKnownUrl(
+      "https://example.com/some/prefix/.well-known/agent-skills"
+    );
+    expect(spec.basePath).toBe("/some/prefix/.well-known/agent-skills");
+  });
+
+  it("includes port in origin", () => {
+    const spec = parseWellKnownUrl("https://example.com:8443");
+    expect(spec.origin).toBe("https://example.com:8443");
+  });
+
+  it("rejects http:// without allowHttp", () => {
+    expect(() => parseWellKnownUrl("http://example.com")).toThrow(/Insecure scheme/);
+  });
+
+  it("accepts http:// when allowHttp = true", () => {
+    const spec = parseWellKnownUrl("http://localhost:8080", true);
+    expect(spec.origin).toBe("http://localhost:8080");
+  });
+
+  it("rejects unsupported schemes", () => {
+    expect(() => parseWellKnownUrl("ftp://example.com")).toThrow(/Unsupported scheme/);
+  });
+
+  it("rejects malformed URLs", () => {
+    expect(() => parseWellKnownUrl("not a url")).toThrow(/Invalid well-known URL/);
+  });
+});
+
+describe("isOriginAllowed", () => {
+  const baseConfig: WellKnownConfig = {
+    pollIntervalMs: 0,
+    cacheDir: "/tmp",
+    allowedOrigins: [],
+    maxArtifactBytes: 1,
+    maxUnpackedBytes: 1,
+    allowHttp: false,
+  };
+
+  it("denies all when allowlist is empty (default-deny)", () => {
+    expect(
+      isOriginAllowed(
+        { origin: "https://example.com", basePath: "/.well-known/agent-skills" },
+        baseConfig
+      )
+    ).toBe(false);
+  });
+
+  it("allows exact origin match", () => {
+    const config = { ...baseConfig, allowedOrigins: ["https://example.com"] };
+    expect(
+      isOriginAllowed(
+        { origin: "https://example.com", basePath: "/.well-known/agent-skills" },
+        config
+      )
+    ).toBe(true);
+  });
+
+  it("is case insensitive on origin", () => {
+    const config = { ...baseConfig, allowedOrigins: ["https://EXAMPLE.com"] };
+    expect(
+      isOriginAllowed(
+        { origin: "https://example.com", basePath: "/.well-known/agent-skills" },
+        config
+      )
+    ).toBe(true);
+  });
+
+  it("does not allow subdomains by accident", () => {
+    const config = { ...baseConfig, allowedOrigins: ["https://example.com"] };
+    expect(
+      isOriginAllowed(
+        { origin: "https://evil.example.com", basePath: "/.well-known/agent-skills" },
+        config
+      )
+    ).toBe(false);
+  });
+
+  it("treats different ports as distinct", () => {
+    const config = { ...baseConfig, allowedOrigins: ["https://example.com"] };
+    expect(
+      isOriginAllowed(
+        { origin: "https://example.com:8443", basePath: "/.well-known/agent-skills" },
+        config
+      )
+    ).toBe(false);
+  });
+});
+
+describe("getWellKnownCacheKey", () => {
+  it("produces a unique key per host + base path", () => {
+    const a = getWellKnownCacheKey({
+      origin: "https://example.com",
+      basePath: "/.well-known/agent-skills",
+    });
+    const b = getWellKnownCacheKey({
+      origin: "https://example.com",
+      basePath: "/team/.well-known/agent-skills",
+    });
+    expect(a).not.toBe(b);
+  });
+
+  it("collapses unsafe characters", () => {
+    const key = getWellKnownCacheKey({
+      origin: "https://example.com:8443",
+      basePath: "/.well-known/agent-skills",
+    });
+    expect(key).not.toMatch(/[^a-z0-9._-]/);
+  });
+});
+
+describe("getWellKnownCachePath", () => {
+  it("places the cache under the given cacheDir", () => {
+    const cachePath = getWellKnownCachePath(
+      { origin: "https://example.com", basePath: "/.well-known/agent-skills" },
+      "/cache"
+    );
+    expect(cachePath.startsWith(path.join("/cache"))).toBe(true);
+  });
+});
+
+describe("URL helpers", () => {
+  const spec = {
+    origin: "https://example.com",
+    basePath: "/.well-known/agent-skills",
+  };
+
+  it("getWellKnownIndexUrl points at index.json", () => {
+    expect(getWellKnownIndexUrl(spec)).toBe(
+      "https://example.com/.well-known/agent-skills/index.json"
+    );
+  });
+
+  it("resolveArtifactUrl resolves path-absolute URLs", () => {
+    expect(resolveArtifactUrl(spec, "/.well-known/agent-skills/foo/SKILL.md")).toBe(
+      "https://example.com/.well-known/agent-skills/foo/SKILL.md"
+    );
+  });
+
+  it("resolveArtifactUrl resolves relative URLs against the index URL", () => {
+    expect(resolveArtifactUrl(spec, "foo/SKILL.md")).toBe(
+      "https://example.com/.well-known/agent-skills/foo/SKILL.md"
+    );
+  });
+
+  it("resolveArtifactUrl preserves absolute URLs", () => {
+    expect(
+      resolveArtifactUrl(spec, "https://cdn.example.com/v2/foo.tar.gz")
+    ).toBe("https://cdn.example.com/v2/foo.tar.gz");
+  });
+});

--- a/src/well-known-config.ts
+++ b/src/well-known-config.ts
@@ -1,0 +1,322 @@
+/**
+ * Well-known agent skills discovery configuration.
+ *
+ * Implements the `.well-known/agent-skills/` discovery RFC
+ * (https://schemas.agentskills.io/discovery/0.2.0/schema.json).
+ *
+ * Mirrors the shape of github-config.ts: URL detection, parsing,
+ * allowlist gating, and cache path computation for a remote source.
+ */
+
+import * as fs from "node:fs";
+import * as os from "node:os";
+import * as path from "node:path";
+import { isGitHubUrl } from "./github-config.js";
+
+/**
+ * Parsed well-known publisher specification.
+ *
+ * `origin` is `<scheme>://<host>[:<port>]` (no trailing slash).
+ * `basePath` is the URL path that contains `/.well-known/agent-skills`,
+ * with no trailing slash. Together they form the index base, and
+ * `<origin><basePath>/index.json` is the document URL.
+ */
+export interface WellKnownSpec {
+  origin: string;
+  basePath: string;
+}
+
+/**
+ * Well-known-specific configuration from environment variables / config file.
+ */
+export interface WellKnownConfig {
+  pollIntervalMs: number;
+  cacheDir: string;
+  allowedOrigins: string[];
+  maxArtifactBytes: number;
+  maxUnpackedBytes: number;
+  allowHttp: boolean;
+}
+
+/**
+ * Default polling interval: 5 minutes (matches GitHub).
+ */
+const DEFAULT_POLL_INTERVAL_MS = 5 * 60 * 1000;
+
+/**
+ * Default size caps. Generous enough for typical skills, small enough
+ * to bound the impact of a malicious or buggy publisher.
+ */
+const DEFAULT_MAX_ARTIFACT_MB = 10;
+const DEFAULT_MAX_UNPACKED_MB = 50;
+
+/**
+ * Default cache directory (sibling to GitHub's cache).
+ */
+const DEFAULT_CACHE_DIR = path.join(os.homedir(), ".skilljack", "well-known-cache");
+
+/**
+ * Required URL fragment that identifies a well-known agent-skills endpoint.
+ */
+export const WELL_KNOWN_PATH_FRAGMENT = "/.well-known/agent-skills";
+
+/**
+ * Check if a path is a well-known URL.
+ *
+ * Detection rule: starts with http(s):// AND is not a GitHub URL.
+ * The URL does not have to include the well-known path fragment yet —
+ * `parseWellKnownUrl()` normalizes it on parse.
+ */
+export function isWellKnownUrl(urlOrPath: string): boolean {
+  if (typeof urlOrPath !== "string") return false;
+  if (!/^https?:\/\//i.test(urlOrPath)) return false;
+  return !isGitHubUrl(urlOrPath);
+}
+
+/**
+ * Parse a well-known publisher URL into a WellKnownSpec.
+ *
+ * Supported inputs:
+ *   https://example.com
+ *   https://example.com/.well-known/agent-skills
+ *   https://example.com/.well-known/agent-skills/
+ *   https://example.com/.well-known/agent-skills/index.json
+ *   https://example.com/some/prefix/.well-known/agent-skills
+ *
+ * If the input path does not include `/.well-known/agent-skills`, it is
+ * appended automatically. A trailing `/index.json` (or trailing slash) is
+ * stripped from `basePath`.
+ *
+ * @throws Error on invalid URL or unsupported scheme.
+ */
+export function parseWellKnownUrl(url: string, allowHttp = false): WellKnownSpec {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`Invalid well-known URL: "${url}"`);
+  }
+
+  if (parsed.protocol !== "https:" && parsed.protocol !== "http:") {
+    throw new Error(`Unsupported scheme for well-known URL: "${url}"`);
+  }
+  if (parsed.protocol === "http:" && !allowHttp) {
+    throw new Error(
+      `Insecure scheme http: rejected for "${url}". ` +
+        `Set WELL_KNOWN_ALLOW_HTTP=1 for local development.`
+    );
+  }
+
+  // Strip trailing /index.json or trailing slashes.
+  let pathName = parsed.pathname;
+  if (pathName.endsWith("/index.json")) {
+    pathName = pathName.slice(0, -"/index.json".length);
+  }
+  pathName = pathName.replace(/\/+$/, "");
+
+  // Append the well-known fragment if absent.
+  if (!pathName.toLowerCase().includes(WELL_KNOWN_PATH_FRAGMENT)) {
+    pathName = pathName + WELL_KNOWN_PATH_FRAGMENT;
+  }
+
+  // Normalize: ensure leading slash, no trailing slash.
+  if (!pathName.startsWith("/")) pathName = "/" + pathName;
+  pathName = pathName.replace(/\/+$/, "");
+
+  const origin = `${parsed.protocol}//${parsed.host}`;
+  return { origin, basePath: pathName };
+}
+
+/**
+ * Check if a well-known origin is allowed by the allowlist.
+ *
+ * Like the GitHub allowlist, an empty allowlist denies all by default
+ * for safety — well-known publishers can serve arbitrary code into the
+ * agent's context.
+ *
+ * Comparison is case-insensitive on the host and exact on scheme/port.
+ */
+export function isOriginAllowed(spec: WellKnownSpec, config: WellKnownConfig): boolean {
+  if (config.allowedOrigins.length === 0) {
+    return false;
+  }
+  const target = spec.origin.toLowerCase();
+  return config.allowedOrigins.some((allowed) => allowed.toLowerCase() === target);
+}
+
+/**
+ * Parse a comma-separated list from an environment variable.
+ */
+function parseCommaList(envValue: string | undefined): string[] {
+  if (!envValue) return [];
+  return envValue
+    .split(",")
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0);
+}
+
+/**
+ * Path to the shared config file (same file used by skill-config / github-config).
+ */
+const CONFIG_FILE_PATH = path.join(os.homedir(), ".skilljack", "config.json");
+
+/**
+ * Load the well-known allowed-origin list from the shared config file.
+ */
+function loadAllowedOriginsFromConfig(): string[] {
+  try {
+    if (fs.existsSync(CONFIG_FILE_PATH)) {
+      const content = fs.readFileSync(CONFIG_FILE_PATH, "utf-8");
+      const parsed = JSON.parse(content);
+      if (Array.isArray(parsed.wellKnownAllowedOrigins)) {
+        return parsed.wellKnownAllowedOrigins.filter(
+          (o: unknown): o is string => typeof o === "string"
+        );
+      }
+    }
+  } catch {
+    // Ignore errors reading config file.
+  }
+  return [];
+}
+
+/**
+ * Parse a positive integer environment variable, falling back to a default.
+ */
+function parseIntEnv(value: string | undefined, fallback: number): number {
+  if (value === undefined) return fallback;
+  const parsed = parseInt(value, 10);
+  if (Number.isNaN(parsed) || parsed < 0) return fallback;
+  return parsed;
+}
+
+/**
+ * Get well-known configuration from environment variables and config file.
+ *
+ * Environment variables:
+ *   WELL_KNOWN_POLL_INTERVAL_MS - Polling interval (0 disables, default 300000)
+ *   WELL_KNOWN_ALLOWED_ORIGINS - Comma-separated allowed origins (env overrides config)
+ *   WELL_KNOWN_MAX_ARTIFACT_MB - Per-artifact size cap (default 10)
+ *   WELL_KNOWN_MAX_UNPACKED_MB - Per-archive uncompressed cap (default 50)
+ *   WELL_KNOWN_ALLOW_HTTP - When "1"/"true"/"yes", permit http:// origins (dev only)
+ *   SKILLJACK_CACHE_DIR - Override cache directory base
+ */
+export function getWellKnownConfig(): WellKnownConfig {
+  const envOrigins = parseCommaList(process.env.WELL_KNOWN_ALLOWED_ORIGINS);
+  const configOrigins = loadAllowedOriginsFromConfig();
+
+  const allowHttpRaw = process.env.WELL_KNOWN_ALLOW_HTTP?.toLowerCase();
+  const allowHttp = allowHttpRaw === "1" || allowHttpRaw === "true" || allowHttpRaw === "yes";
+
+  const cacheBase = process.env.SKILLJACK_CACHE_DIR;
+  // SKILLJACK_CACHE_DIR is shared with GitHub. If set, place the well-known
+  // cache underneath it as a sibling sub-namespace.
+  const cacheDir = cacheBase
+    ? path.join(cacheBase, "well-known")
+    : DEFAULT_CACHE_DIR;
+
+  const maxArtifactMb = parseIntEnv(process.env.WELL_KNOWN_MAX_ARTIFACT_MB, DEFAULT_MAX_ARTIFACT_MB);
+  const maxUnpackedMb = parseIntEnv(process.env.WELL_KNOWN_MAX_UNPACKED_MB, DEFAULT_MAX_UNPACKED_MB);
+
+  return {
+    pollIntervalMs: parseIntEnv(process.env.WELL_KNOWN_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS),
+    cacheDir,
+    allowedOrigins: envOrigins.length > 0 ? envOrigins : configOrigins,
+    maxArtifactBytes: maxArtifactMb * 1024 * 1024,
+    maxUnpackedBytes: maxUnpackedMb * 1024 * 1024,
+    allowHttp,
+  };
+}
+
+/**
+ * Slugify a URL path/host segment for use as a filesystem path.
+ * Replaces unsafe characters and collapses runs.
+ */
+function slugify(input: string): string {
+  return input
+    .toLowerCase()
+    .replace(/[^a-z0-9.-]+/g, "-")
+    .replace(/-{2,}/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+/**
+ * Compute a unique filesystem-safe key for a well-known publisher.
+ * Combines the host (with port) and a slug of the base path.
+ */
+export function getWellKnownCacheKey(spec: WellKnownSpec): string {
+  const url = new URL(spec.origin);
+  const hostKey = slugify(url.host) || "unknown-host";
+  // Drop the well-known fragment from the base path before slugging — it's
+  // shared by all publishers and adds no disambiguation.
+  let pathPart = spec.basePath;
+  const fragmentIdx = pathPart.toLowerCase().indexOf(WELL_KNOWN_PATH_FRAGMENT);
+  if (fragmentIdx !== -1) {
+    pathPart = pathPart.slice(0, fragmentIdx);
+  }
+  const pathSlug = slugify(pathPart);
+  return pathSlug ? `${hostKey}_${pathSlug}` : hostKey;
+}
+
+/**
+ * Get the cache root for a well-known publisher.
+ */
+export function getWellKnownCachePath(spec: WellKnownSpec, cacheDir: string): string {
+  return path.join(cacheDir, getWellKnownCacheKey(spec));
+}
+
+/**
+ * Path to the cached index.json document.
+ */
+export function getWellKnownIndexPath(spec: WellKnownSpec, cacheDir: string): string {
+  return path.join(getWellKnownCachePath(spec, cacheDir), "index.json");
+}
+
+/**
+ * Path to the cached metadata sidecar (ETag/Last-Modified hints).
+ */
+export function getWellKnownMetaPath(spec: WellKnownSpec, cacheDir: string): string {
+  return path.join(getWellKnownCachePath(spec, cacheDir), ".index-meta.json");
+}
+
+/**
+ * Path to a per-skill subdirectory under the publisher's cache root.
+ */
+export function getWellKnownSkillPath(
+  spec: WellKnownSpec,
+  skillName: string,
+  cacheDir: string
+): string {
+  return path.join(getWellKnownCachePath(spec, cacheDir), "skills", skillName);
+}
+
+/**
+ * Compute the URL for the publisher's index.json document.
+ */
+export function getWellKnownIndexUrl(spec: WellKnownSpec): string {
+  return `${spec.origin}${spec.basePath}/index.json`;
+}
+
+/**
+ * Resolve an entry's `url` field against the index URL per RFC 3986.
+ * Supports absolute, path-absolute, and relative URLs.
+ */
+export function resolveArtifactUrl(spec: WellKnownSpec, entryUrl: string): string {
+  const indexUrl = getWellKnownIndexUrl(spec);
+  return new URL(entryUrl, indexUrl).toString();
+}
+
+/**
+ * Display name for UI / logging.
+ */
+export function getWellKnownDisplayName(spec: WellKnownSpec): string {
+  return `${spec.origin}${spec.basePath}`;
+}
+
+/**
+ * Prefix used to namespace skill names from this publisher (mirrors the
+ * `owner-repo` GitHub prefix).
+ */
+export function getWellKnownPrefix(spec: WellKnownSpec): string {
+  return getWellKnownCacheKey(spec);
+}

--- a/src/well-known-config.ts
+++ b/src/well-known-config.ts
@@ -145,6 +145,51 @@ export function isOriginAllowed(spec: WellKnownSpec, config: WellKnownConfig): b
 }
 
 /**
+ * Validate that an arbitrary URL is safe to fetch: it must use an allowed
+ * scheme (https, or http only when allowHttp is set) and its origin must be on
+ * the allowlist. Throws with a descriptive message otherwise, returning the
+ * parsed URL on success.
+ *
+ * This is the trust boundary for every network request the well-known source
+ * makes — not just the configured index origin, but each skill entry's artifact
+ * `url` and any redirect target. Without it, an allowlisted-but-malicious
+ * publisher could point `url` at an internal endpoint (SSRF) or an off-allowlist
+ * host, bypassing both the origin allowlist and the http scheme gate.
+ */
+export function assertUrlAllowed(
+  rawUrl: string,
+  config: Pick<WellKnownConfig, "allowedOrigins" | "allowHttp">,
+  label = "URL"
+): URL {
+  let parsed: URL;
+  try {
+    parsed = new URL(rawUrl);
+  } catch {
+    throw new Error(`${label} is not a valid absolute URL: "${rawUrl}"`);
+  }
+
+  const isHttps = parsed.protocol === "https:";
+  const isAllowedHttp = config.allowHttp && parsed.protocol === "http:";
+  if (!isHttps && !isAllowedHttp) {
+    throw new Error(
+      `${label} uses disallowed scheme "${parsed.protocol}": ${rawUrl}`
+    );
+  }
+
+  const origin = `${parsed.protocol}//${parsed.host}`;
+  const allowed = config.allowedOrigins.some(
+    (o) => o.toLowerCase() === origin.toLowerCase()
+  );
+  if (!allowed) {
+    throw new Error(
+      `${label} origin "${origin}" is not in WELL_KNOWN_ALLOWED_ORIGINS: ${rawUrl}`
+    );
+  }
+
+  return parsed;
+}
+
+/**
  * Parse a comma-separated list from an environment variable.
  */
 function parseCommaList(envValue: string | undefined): string[] {
@@ -181,12 +226,21 @@ function loadAllowedOriginsFromConfig(): string[] {
 }
 
 /**
- * Parse a positive integer environment variable, falling back to a default.
+ * Parse a non-negative integer environment variable, falling back to a default.
+ *
+ * `minValue` sets the smallest accepted value: size caps pass `1` so that
+ * `WELL_KNOWN_MAX_ARTIFACT_MB=0` (a 0-byte cap that would fail every fetch)
+ * falls back to the default instead of silently disabling the feature. The
+ * poll interval keeps `minValue = 0`, where `0` meaningfully disables polling.
  */
-function parseIntEnv(value: string | undefined, fallback: number): number {
+function parseIntEnv(
+  value: string | undefined,
+  fallback: number,
+  minValue = 0
+): number {
   if (value === undefined) return fallback;
   const parsed = parseInt(value, 10);
-  if (Number.isNaN(parsed) || parsed < 0) return fallback;
+  if (Number.isNaN(parsed) || parsed < minValue) return fallback;
   return parsed;
 }
 
@@ -215,8 +269,10 @@ export function getWellKnownConfig(): WellKnownConfig {
     ? path.join(cacheBase, "well-known")
     : DEFAULT_CACHE_DIR;
 
-  const maxArtifactMb = parseIntEnv(process.env.WELL_KNOWN_MAX_ARTIFACT_MB, DEFAULT_MAX_ARTIFACT_MB);
-  const maxUnpackedMb = parseIntEnv(process.env.WELL_KNOWN_MAX_UNPACKED_MB, DEFAULT_MAX_UNPACKED_MB);
+  // minValue 1: a 0-byte cap is a footgun (fails every fetch), so fall back to
+  // the default rather than silently disabling downloads.
+  const maxArtifactMb = parseIntEnv(process.env.WELL_KNOWN_MAX_ARTIFACT_MB, DEFAULT_MAX_ARTIFACT_MB, 1);
+  const maxUnpackedMb = parseIntEnv(process.env.WELL_KNOWN_MAX_UNPACKED_MB, DEFAULT_MAX_UNPACKED_MB, 1);
 
   return {
     pollIntervalMs: parseIntEnv(process.env.WELL_KNOWN_POLL_INTERVAL_MS, DEFAULT_POLL_INTERVAL_MS),

--- a/src/well-known-polling.test.ts
+++ b/src/well-known-polling.test.ts
@@ -76,7 +76,13 @@ describe("createWellKnownPollingManager", () => {
     server = await startServer();
     cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "wkpoll-"));
     spec = { origin: server.baseUrl, basePath: "/.well-known/agent-skills" };
-    options = { cacheDir, maxArtifactBytes: 1024 * 1024, maxUnpackedBytes: 1024 * 1024 };
+    options = {
+      cacheDir,
+      maxArtifactBytes: 1024 * 1024,
+      maxUnpackedBytes: 1024 * 1024,
+      allowedOrigins: [server.baseUrl],
+      allowHttp: true,
+    };
   });
 
   afterEach(async () => {

--- a/src/well-known-polling.test.ts
+++ b/src/well-known-polling.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import { createWellKnownPollingManager } from "./well-known-polling.js";
+import { syncWellKnown, SyncOptions } from "./well-known-sync.js";
+import { WellKnownSpec } from "./well-known-config.js";
+
+function digestOf(s: string): string {
+  return "sha256:" + crypto.createHash("sha256").update(s).digest("hex");
+}
+
+function skillBody(name: string, version: string): string {
+  return `---\nname: ${name}\ndescription: ${name} skill\n---\n\nversion: ${version}\n`;
+}
+
+interface FixtureServer {
+  baseUrl: string;
+  setIndex(body: string): void;
+  setRoute(path: string, body: string, contentType?: string): void;
+  close(): Promise<void>;
+}
+
+async function startServer(): Promise<FixtureServer> {
+  const routes = new Map<string, { body: Buffer; contentType: string; etag: string }>();
+  const server = http.createServer((req, res) => {
+    const route = routes.get(req.url ?? "");
+    if (!route) {
+      res.writeHead(404).end();
+      return;
+    }
+    const inm = req.headers["if-none-match"];
+    if (inm && inm === route.etag) {
+      res.writeHead(304).end();
+      return;
+    }
+    res.writeHead(200, {
+      "Content-Type": route.contentType,
+      "Content-Length": String(route.body.byteLength),
+      ETag: route.etag,
+    });
+    res.end(route.body);
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const port = (server.address() as { port: number }).port;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    setIndex(body: string) {
+      this.setRoute("/.well-known/agent-skills/index.json", body, "application/json");
+    },
+    setRoute(p: string, body: string, contentType = "text/markdown") {
+      const buf = Buffer.from(body, "utf-8");
+      routes.set(p, {
+        body: buf,
+        contentType,
+        etag: '"' + crypto.createHash("sha256").update(buf).digest("hex").slice(0, 16) + '"',
+      });
+    },
+    async close() {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      );
+    },
+  };
+}
+
+describe("createWellKnownPollingManager", () => {
+  let server: FixtureServer;
+  let cacheDir: string;
+  let spec: WellKnownSpec;
+  let options: SyncOptions;
+
+  beforeEach(async () => {
+    server = await startServer();
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "wkpoll-"));
+    spec = { origin: server.baseUrl, basePath: "/.well-known/agent-skills" };
+    options = { cacheDir, maxArtifactBytes: 1024 * 1024, maxUnpackedBytes: 1024 * 1024 };
+  });
+
+  afterEach(async () => {
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+    await server.close();
+  });
+
+  it("calls onUpdate when the index changes", async () => {
+    // Initial state.
+    const aBody = skillBody("alpha", "1");
+    server.setRoute("/.well-known/agent-skills/alpha/SKILL.md", aBody);
+    server.setIndex(
+      JSON.stringify({
+        $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+        skills: [
+          {
+            name: "alpha",
+            type: "skill-md",
+            description: "a",
+            url: "/.well-known/agent-skills/alpha/SKILL.md",
+            digest: digestOf(aBody),
+          },
+        ],
+      })
+    );
+
+    // Prime the cache.
+    const first = await syncWellKnown(spec, options);
+    expect(first.skillsSynced).toEqual(["alpha"]);
+
+    let updateCount = 0;
+    const updates: string[] = [];
+    const manager = createWellKnownPollingManager([spec], options, {
+      intervalMs: 0, // We'll trigger checkNow manually
+      onUpdate: (s) => {
+        updateCount += 1;
+        updates.push(s.origin);
+      },
+    });
+
+    // No change → no update.
+    await manager.checkNow();
+    expect(updateCount).toBe(0);
+
+    // Change the published artifact (and thus the index digest).
+    const aBody2 = skillBody("alpha", "2");
+    server.setRoute("/.well-known/agent-skills/alpha/SKILL.md", aBody2);
+    server.setIndex(
+      JSON.stringify({
+        $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+        skills: [
+          {
+            name: "alpha",
+            type: "skill-md",
+            description: "a",
+            url: "/.well-known/agent-skills/alpha/SKILL.md",
+            digest: digestOf(aBody2),
+          },
+        ],
+      })
+    );
+
+    await manager.checkNow();
+    expect(updateCount).toBe(1);
+    expect(updates).toEqual([server.baseUrl]);
+  });
+
+  it("does not start the timer when interval <= 0", () => {
+    const manager = createWellKnownPollingManager([spec], options, {
+      intervalMs: 0,
+      onUpdate: () => {},
+    });
+    manager.start();
+    expect(manager.isRunning()).toBe(false);
+  });
+
+  it("does not start the timer when there are no specs", () => {
+    const manager = createWellKnownPollingManager([], options, {
+      intervalMs: 1000,
+      onUpdate: () => {},
+    });
+    manager.start();
+    expect(manager.isRunning()).toBe(false);
+  });
+});

--- a/src/well-known-polling.ts
+++ b/src/well-known-polling.ts
@@ -1,0 +1,107 @@
+/**
+ * Well-known publisher polling.
+ *
+ * Periodically checks each configured publisher's index.json for changes
+ * and triggers a sync when the document has actually moved. Uses the same
+ * shape as github-polling.ts so the wiring in index.ts is symmetrical.
+ */
+
+import { WellKnownSpec } from "./well-known-config.js";
+import { SyncOptions, SyncResult, hasRemoteUpdates, syncWellKnown } from "./well-known-sync.js";
+
+export interface PollingOptions {
+  intervalMs: number;
+  onUpdate: (spec: WellKnownSpec, result: SyncResult) => void;
+  onError?: (spec: WellKnownSpec, error: Error) => void;
+}
+
+export interface PollingManager {
+  start(): void;
+  stop(): void;
+  checkNow(): Promise<void>;
+  isRunning(): boolean;
+}
+
+export function createWellKnownPollingManager(
+  specs: WellKnownSpec[],
+  syncOptions: SyncOptions,
+  pollingOptions: PollingOptions
+): PollingManager {
+  let intervalId: NodeJS.Timeout | null = null;
+  let isChecking = false;
+
+  async function checkForUpdates(): Promise<void> {
+    if (isChecking) {
+      console.error("Well-known polling: already checking, skipping...");
+      return;
+    }
+    if (specs.length === 0) return;
+
+    isChecking = true;
+    console.error(`Well-known polling: checking ${specs.length} publisher(s) for updates...`);
+
+    for (const spec of specs) {
+      try {
+        const hasUpdates = await hasRemoteUpdates(spec, syncOptions);
+        if (!hasUpdates) continue;
+
+        console.error(`Well-known polling: updates available for ${spec.origin}`);
+        const result = await syncWellKnown(spec, syncOptions);
+        if (!result.error && result.updated) {
+          pollingOptions.onUpdate(spec, result);
+        }
+      } catch (error) {
+        const err = error instanceof Error ? error : new Error(String(error));
+        console.error(
+          `Well-known polling: error checking ${spec.origin}: ${err.message}`
+        );
+        pollingOptions.onError?.(spec, err);
+      }
+    }
+
+    isChecking = false;
+  }
+
+  return {
+    start(): void {
+      if (intervalId !== null) {
+        console.error("Well-known polling: already running");
+        return;
+      }
+      if (pollingOptions.intervalMs <= 0) {
+        console.error("Well-known polling: disabled (interval <= 0)");
+        return;
+      }
+      if (specs.length === 0) {
+        console.error("Well-known polling: not starting (no publishers configured)");
+        return;
+      }
+
+      console.error(
+        `Well-known polling: starting with ${pollingOptions.intervalMs}ms interval ` +
+          `for ${specs.length} publisher(s)`
+      );
+
+      intervalId = setInterval(() => {
+        checkForUpdates().catch((error) => {
+          console.error(`Well-known polling: unexpected error: ${error}`);
+        });
+      }, pollingOptions.intervalMs);
+    },
+
+    stop(): void {
+      if (intervalId === null) return;
+      console.error("Well-known polling: stopping");
+      clearInterval(intervalId);
+      intervalId = null;
+    },
+
+    async checkNow(): Promise<void> {
+      await checkForUpdates();
+    },
+
+    isRunning(): boolean {
+      return intervalId !== null;
+    },
+  };
+}

--- a/src/well-known-sync.test.ts
+++ b/src/well-known-sync.test.ts
@@ -39,6 +39,8 @@ interface RouteResponse {
   contentType?: string;
   body: Buffer | string;
   delay?: number;
+  /** Extra response headers (e.g. Location for redirects). */
+  headers?: Record<string, string>;
 }
 
 interface FixtureServer {
@@ -59,6 +61,7 @@ async function startFixtureServer(): Promise<FixtureServer> {
     res.writeHead(route.status ?? 200, {
       "Content-Type": route.contentType ?? "application/octet-stream",
       "Content-Length": String(body.byteLength),
+      ...route.headers,
     });
     if (route.delay) {
       setTimeout(() => res.end(body), route.delay);
@@ -235,6 +238,8 @@ describe("syncWellKnown", () => {
       cacheDir,
       maxArtifactBytes: 1024 * 1024,
       maxUnpackedBytes: 1024 * 1024,
+      allowedOrigins: [server.baseUrl],
+      allowHttp: true,
     };
   });
 
@@ -322,6 +327,62 @@ describe("syncWellKnown", () => {
     expect(result.error).toBeUndefined();
     expect(result.skillErrors.big).toMatch(/exceeds size cap/);
     expect(result.skillsSynced).toEqual([]);
+  });
+
+  it("rejects an artifact url whose origin is not on the allowlist (SSRF guard)", async () => {
+    const body = makeSkillMd("evil", "x");
+    // Absolute cross-origin url — a would-be SSRF target. It is allowlist-gated
+    // and never fetched, even though its digest would match.
+    const offOrigin = "http://169.254.169.254/latest/meta-data/SKILL.md";
+    setIndex([
+      { name: "evil", type: "skill-md", description: "evil", url: offOrigin, digest: digestOf(body) },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+
+    expect(result.error).toBeUndefined();
+    expect(result.skillsSynced).toEqual([]);
+    expect(result.skillErrors.evil).toMatch(/not in WELL_KNOWN_ALLOWED_ORIGINS/);
+  });
+
+  it("rejects a redirect that leaves the allowlist", async () => {
+    const body = makeSkillMd("redir", "x");
+    const { url, digest } = setSkillMd("redir", body);
+    // Same-origin artifact url, but the server 302s it off-allowlist.
+    server.routes.set(url, {
+      status: 302,
+      body: "",
+      headers: { Location: "http://169.254.169.254/evil" },
+    });
+    setIndex([
+      { name: "redir", type: "skill-md", description: "redir", url, digest },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+
+    expect(result.error).toBeUndefined();
+    expect(result.skillsSynced).toEqual([]);
+    expect(result.skillErrors.redir).toMatch(/not in WELL_KNOWN_ALLOWED_ORIGINS/);
+  }, 15000);
+
+  it("follows a same-origin redirect that stays on the allowlist", async () => {
+    const body = makeSkillMd("hop", "x");
+    const finalPath = "/.well-known/agent-skills/hop/real-SKILL.md";
+    server.routes.set(finalPath, { contentType: "text/markdown", body });
+    const startPath = "/.well-known/agent-skills/hop/SKILL.md";
+    server.routes.set(startPath, {
+      status: 302,
+      body: "",
+      headers: { Location: finalPath },
+    });
+    setIndex([
+      { name: "hop", type: "skill-md", description: "hop", url: startPath, digest: digestOf(body) },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+
+    expect(result.skillErrors).toEqual({});
+    expect(result.skillsSynced).toEqual(["hop"]);
   });
 
   it("warns and skips entries with unknown type, but other entries still load", async () => {

--- a/src/well-known-sync.test.ts
+++ b/src/well-known-sync.test.ts
@@ -1,0 +1,471 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as http from "node:http";
+import * as os from "node:os";
+import * as path from "node:path";
+import * as zlib from "node:zlib";
+import * as tar from "tar";
+import {
+  syncWellKnown,
+  validateIndexDocument,
+  archiveFormatFromUrl,
+  IndexEntry,
+  SyncOptions,
+} from "./well-known-sync.js";
+import { WellKnownSpec, getWellKnownIndexPath, getWellKnownSkillPath } from "./well-known-config.js";
+
+/**
+ * SHA-256 of a buffer in `sha256:<hex>` form (matches well-known-sync's format).
+ */
+function digestOf(data: Buffer | string): string {
+  const buf = typeof data === "string" ? Buffer.from(data, "utf-8") : data;
+  return "sha256:" + crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Build a SKILL.md with valid frontmatter and the given name/description.
+ */
+function makeSkillMd(name: string, description: string, body = "Test skill body."): string {
+  return `---\nname: ${name}\ndescription: ${description}\n---\n\n${body}\n`;
+}
+
+/**
+ * Tiny HTTP fixture: serves a route table of `path → response`. Updates to
+ * the table take effect immediately (so tests can swap responses mid-sync).
+ */
+interface RouteResponse {
+  status?: number;
+  contentType?: string;
+  body: Buffer | string;
+  delay?: number;
+}
+
+interface FixtureServer {
+  baseUrl: string;
+  routes: Map<string, RouteResponse>;
+  close(): Promise<void>;
+}
+
+async function startFixtureServer(): Promise<FixtureServer> {
+  const routes = new Map<string, RouteResponse>();
+  const server = http.createServer((req, res) => {
+    const route = routes.get(req.url ?? "");
+    if (!route) {
+      res.writeHead(404).end("not found");
+      return;
+    }
+    const body = typeof route.body === "string" ? Buffer.from(route.body) : route.body;
+    res.writeHead(route.status ?? 200, {
+      "Content-Type": route.contentType ?? "application/octet-stream",
+      "Content-Length": String(body.byteLength),
+    });
+    if (route.delay) {
+      setTimeout(() => res.end(body), route.delay);
+    } else {
+      res.end(body);
+    }
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const addr = server.address();
+  const port = typeof addr === "object" && addr ? addr.port : 0;
+  return {
+    baseUrl: `http://127.0.0.1:${port}`,
+    routes,
+    async close() {
+      await new Promise<void>((resolve, reject) =>
+        server.close((err) => (err ? reject(err) : resolve()))
+      );
+    },
+  };
+}
+
+/**
+ * Build a small tar.gz buffer containing the given file map.
+ * `files` keys are entry paths inside the archive (relative).
+ */
+async function makeTarGz(files: Record<string, string>): Promise<Buffer> {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "wktest-"));
+  try {
+    for (const [name, content] of Object.entries(files)) {
+      const target = path.join(tmpRoot, name);
+      fs.mkdirSync(path.dirname(target), { recursive: true });
+      fs.writeFileSync(target, content);
+    }
+    const tgzPath = path.join(tmpRoot, "out.tar.gz");
+    await tar.c(
+      { gzip: true, cwd: tmpRoot, file: tgzPath },
+      Object.keys(files)
+    );
+    return fs.readFileSync(tgzPath);
+  } finally {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Build a malicious tar.gz containing an entry whose name attempts path
+ * traversal. We construct the tar manually because the `tar` library
+ * normalizes relative paths during creation.
+ */
+function makeMaliciousTarGz(entryName: string, content: string): Buffer {
+  // POSIX ustar header is 512 bytes; pad name field exactly.
+  const block = Buffer.alloc(512);
+  block.write(entryName, 0, 100, "utf-8");
+  // mode: 0644
+  block.write("0000644 ", 100, 8, "utf-8");
+  // uid/gid
+  block.write("0000000 ", 108, 8, "utf-8");
+  block.write("0000000 ", 116, 8, "utf-8");
+  // size in octal
+  const size = Buffer.byteLength(content, "utf-8");
+  block.write(size.toString(8).padStart(11, "0") + " ", 124, 12, "utf-8");
+  // mtime
+  block.write(Math.floor(Date.now() / 1000).toString(8).padStart(11, "0") + " ", 136, 12, "utf-8");
+  // checksum placeholder (8 spaces during sum)
+  block.write("        ", 148, 8, "utf-8");
+  // typeflag '0' = regular file
+  block.write("0", 156, 1, "utf-8");
+  // ustar magic
+  block.write("ustar\x0000", 257, 8, "utf-8");
+  // Compute checksum
+  let sum = 0;
+  for (let i = 0; i < 512; i++) sum += block[i];
+  const chk = sum.toString(8).padStart(6, "0") + "\x00 ";
+  block.write(chk, 148, 8, "binary");
+
+  const data = Buffer.from(content, "utf-8");
+  const padding = Buffer.alloc((512 - (data.byteLength % 512)) % 512);
+  // Two trailing zero blocks signal end of archive
+  const trailer = Buffer.alloc(1024);
+
+  const tarBytes = Buffer.concat([block, data, padding, trailer]);
+  return zlib.gzipSync(tarBytes);
+}
+
+describe("validateIndexDocument", () => {
+  it("accepts a minimal valid v0.2.0 index", () => {
+    const doc = {
+      $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+      skills: [
+        {
+          name: "demo",
+          type: "skill-md",
+          description: "Demo skill",
+          url: "/.well-known/agent-skills/demo/SKILL.md",
+          digest: "sha256:" + "a".repeat(64),
+        },
+      ],
+    };
+    const out = validateIndexDocument(doc);
+    expect(out.skills).toHaveLength(1);
+    expect(out.skills[0].name).toBe("demo");
+  });
+
+  it("rejects non-object input", () => {
+    expect(() => validateIndexDocument(42 as unknown)).toThrow();
+  });
+
+  it("rejects when skills is not an array", () => {
+    expect(() => validateIndexDocument({ skills: "nope" })).toThrow(/skills.*array/);
+  });
+
+  it("skips entries with malformed digest", () => {
+    const out = validateIndexDocument({
+      skills: [
+        {
+          name: "demo",
+          type: "skill-md",
+          description: "x",
+          url: "/x",
+          digest: "sha512:" + "a".repeat(128),
+        },
+      ],
+    });
+    expect(out.skills).toHaveLength(0);
+  });
+
+  it("skips entries with invalid skill names", () => {
+    const out = validateIndexDocument({
+      skills: [
+        {
+          name: "Bad-Name",
+          type: "skill-md",
+          description: "x",
+          url: "/x",
+          digest: "sha256:" + "0".repeat(64),
+        },
+      ],
+    });
+    expect(out.skills).toHaveLength(0);
+  });
+});
+
+describe("archiveFormatFromUrl", () => {
+  it("detects tar.gz", () => {
+    expect(archiveFormatFromUrl("https://x.com/foo.tar.gz")).toBe("tar.gz");
+    expect(archiveFormatFromUrl("https://x.com/foo.tgz")).toBe("tar.gz");
+  });
+  it("detects zip", () => {
+    expect(archiveFormatFromUrl("https://x.com/foo.zip")).toBe("zip");
+  });
+  it("ignores query and fragment", () => {
+    expect(archiveFormatFromUrl("https://x.com/foo.tar.gz?v=1#h")).toBe("tar.gz");
+  });
+  it("returns null for unrecognized", () => {
+    expect(archiveFormatFromUrl("https://x.com/foo")).toBe(null);
+    expect(archiveFormatFromUrl("https://x.com/SKILL.md")).toBe(null);
+  });
+});
+
+describe("syncWellKnown", () => {
+  let server: FixtureServer;
+  let cacheDir: string;
+  let spec: WellKnownSpec;
+  let options: SyncOptions;
+
+  beforeEach(async () => {
+    server = await startFixtureServer();
+    cacheDir = fs.mkdtempSync(path.join(os.tmpdir(), "wkcache-"));
+    spec = {
+      origin: server.baseUrl,
+      basePath: "/.well-known/agent-skills",
+    };
+    options = {
+      cacheDir,
+      maxArtifactBytes: 1024 * 1024,
+      maxUnpackedBytes: 1024 * 1024,
+    };
+  });
+
+  afterEach(async () => {
+    await server.close();
+    fs.rmSync(cacheDir, { recursive: true, force: true });
+  });
+
+  function setSkillMd(name: string, body: string): { url: string; digest: string } {
+    const url = `/.well-known/agent-skills/${name}/SKILL.md`;
+    server.routes.set(url, {
+      contentType: "text/markdown",
+      body,
+    });
+    return { url, digest: digestOf(body) };
+  }
+
+  function setIndex(entries: IndexEntry[]): void {
+    const doc = {
+      $schema: "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+      skills: entries,
+    };
+    server.routes.set("/.well-known/agent-skills/index.json", {
+      contentType: "application/json",
+      body: JSON.stringify(doc),
+    });
+  }
+
+  it("syncs a single skill-md entry, verifying digest", async () => {
+    const body = makeSkillMd("demo", "A demo skill.");
+    const { url, digest } = setSkillMd("demo", body);
+    setIndex([
+      { name: "demo", type: "skill-md", description: "demo", url, digest },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+
+    expect(result.error).toBeUndefined();
+    expect(result.skillsSynced).toEqual(["demo"]);
+    expect(result.updated).toBe(true);
+
+    const skillPath = path.join(getWellKnownSkillPath(spec, "demo", cacheDir), "SKILL.md");
+    expect(fs.existsSync(skillPath)).toBe(true);
+    expect(fs.readFileSync(skillPath, "utf-8")).toBe(body);
+
+    // Cached index.json is written after a successful sync.
+    expect(fs.existsSync(getWellKnownIndexPath(spec, cacheDir))).toBe(true);
+  });
+
+  it("rejects an entry whose digest does not match the artifact", async () => {
+    const body = makeSkillMd("demo", "valid body");
+    const { url } = setSkillMd("demo", body);
+    setIndex([
+      {
+        name: "demo",
+        type: "skill-md",
+        description: "demo",
+        url,
+        digest: "sha256:" + "0".repeat(64),
+      },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+
+    expect(result.error).toBeUndefined(); // top-level fetch succeeded
+    expect(result.skillsSynced).toEqual([]);
+    expect(result.skillErrors.demo).toMatch(/Digest mismatch/);
+    const skillPath = path.join(getWellKnownSkillPath(spec, "demo", cacheDir), "SKILL.md");
+    expect(fs.existsSync(skillPath)).toBe(false);
+  });
+
+  it("rejects oversized artifacts (size cap)", async () => {
+    const big = "x".repeat(5000);
+    const body = makeSkillMd("big", "huge", big);
+    const { url, digest } = setSkillMd("big", body);
+    setIndex([
+      { name: "big", type: "skill-md", description: "big", url, digest },
+    ]);
+
+    // Cap is large enough for the small index but small enough to reject the
+    // 5KB skill body.
+    const tinyOptions = { ...options, maxArtifactBytes: 1000 };
+    const result = await syncWellKnown(spec, tinyOptions);
+
+    expect(result.error).toBeUndefined();
+    expect(result.skillErrors.big).toMatch(/exceeds size cap/);
+    expect(result.skillsSynced).toEqual([]);
+  });
+
+  it("warns and skips entries with unknown type, but other entries still load", async () => {
+    const body = makeSkillMd("good", "ok");
+    const { url, digest } = setSkillMd("good", body);
+    setIndex([
+      {
+        name: "exotic",
+        type: "future-format",
+        description: "x",
+        url: "/x",
+        digest: "sha256:" + "0".repeat(64),
+      },
+      { name: "good", type: "skill-md", description: "good", url, digest },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+    expect(result.skillsSynced).toEqual(["good"]);
+    const goodPath = path.join(getWellKnownSkillPath(spec, "good", cacheDir), "SKILL.md");
+    expect(fs.existsSync(goodPath)).toBe(true);
+  });
+
+  it("syncs a tar.gz archive entry safely", async () => {
+    const skillBody = makeSkillMd("wrangler", "Cloudflare worker tool");
+    const buf = await makeTarGz({
+      "SKILL.md": skillBody,
+      "scripts/deploy.sh": "#!/bin/sh\necho hi\n",
+    });
+    server.routes.set("/.well-known/agent-skills/wrangler.tar.gz", {
+      contentType: "application/gzip",
+      body: buf,
+    });
+    setIndex([
+      {
+        name: "wrangler",
+        type: "archive",
+        description: "Cloudflare worker tool",
+        url: "/.well-known/agent-skills/wrangler.tar.gz",
+        digest: digestOf(buf),
+      },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+    expect(result.error).toBeUndefined();
+    expect(result.skillErrors).toEqual({});
+    expect(result.skillsSynced).toEqual(["wrangler"]);
+
+    const skillDir = getWellKnownSkillPath(spec, "wrangler", cacheDir);
+    expect(fs.existsSync(path.join(skillDir, "SKILL.md"))).toBe(true);
+    expect(fs.existsSync(path.join(skillDir, "scripts", "deploy.sh"))).toBe(true);
+  });
+
+  it("rejects a tar.gz archive missing SKILL.md at the root", async () => {
+    const buf = await makeTarGz({ "other.md": "no skill md here" });
+    server.routes.set("/.well-known/agent-skills/empty.tar.gz", {
+      contentType: "application/gzip",
+      body: buf,
+    });
+    setIndex([
+      {
+        name: "empty",
+        type: "archive",
+        description: "x",
+        url: "/.well-known/agent-skills/empty.tar.gz",
+        digest: digestOf(buf),
+      },
+    ]);
+    const result = await syncWellKnown(spec, options);
+    expect(result.skillErrors.empty).toMatch(/did not contain SKILL\.md/);
+    expect(fs.existsSync(getWellKnownSkillPath(spec, "empty", cacheDir))).toBe(false);
+  });
+
+  it("rejects a tar.gz archive containing a path-traversal entry", async () => {
+    const evilTar = makeMaliciousTarGz("../escape.txt", "pwn");
+    server.routes.set("/.well-known/agent-skills/evil.tar.gz", {
+      contentType: "application/gzip",
+      body: evilTar,
+    });
+    setIndex([
+      {
+        name: "evil",
+        type: "archive",
+        description: "x",
+        url: "/.well-known/agent-skills/evil.tar.gz",
+        digest: digestOf(evilTar),
+      },
+    ]);
+
+    const result = await syncWellKnown(spec, options);
+    // Either the tar filter silently drops the entry (no SKILL.md follows, so
+    // the SKILL.md check trips), or extraction throws outright. Either way,
+    // the skill should not be marked as synced and no escape file should
+    // exist outside the skill dir.
+    expect(result.skillsSynced).toEqual([]);
+    const escaped = path.join(path.dirname(getWellKnownSkillPath(spec, "evil", cacheDir)), "escape.txt");
+    expect(fs.existsSync(escaped)).toBe(false);
+  });
+
+  it("prunes per-skill cache directories when a skill is removed from the index", async () => {
+    const aBody = makeSkillMd("alpha", "A");
+    const bBody = makeSkillMd("beta", "B");
+    const a = setSkillMd("alpha", aBody);
+    const b = setSkillMd("beta", bBody);
+    setIndex([
+      { name: "alpha", type: "skill-md", description: "A", url: a.url, digest: a.digest },
+      { name: "beta", type: "skill-md", description: "B", url: b.url, digest: b.digest },
+    ]);
+
+    let result = await syncWellKnown(spec, options);
+    expect(result.skillsSynced.sort()).toEqual(["alpha", "beta"]);
+
+    // Remove beta from the index and re-sync.
+    setIndex([
+      { name: "alpha", type: "skill-md", description: "A", url: a.url, digest: a.digest },
+    ]);
+    result = await syncWellKnown(spec, options);
+    expect(result.skillsRemoved).toEqual(["beta"]);
+    expect(fs.existsSync(getWellKnownSkillPath(spec, "alpha", cacheDir))).toBe(true);
+    expect(fs.existsSync(getWellKnownSkillPath(spec, "beta", cacheDir))).toBe(false);
+  });
+
+  it("re-uses the cache when digests are unchanged on a re-sync", async () => {
+    const body = makeSkillMd("demo", "x");
+    const { url, digest } = setSkillMd("demo", body);
+    setIndex([
+      { name: "demo", type: "skill-md", description: "x", url, digest },
+    ]);
+    const first = await syncWellKnown(spec, options);
+    expect(first.skillsSynced).toEqual(["demo"]);
+
+    // Replace the on-disk artifact with junk, then resync. Because the digest
+    // hasn't changed AND the SKILL.md still exists, we should skip downloads.
+    // The artifact body on the file system stays whatever the cache had —
+    // but here the file is still good from the first sync. We just check the
+    // second sync reports no work.
+    const second = await syncWellKnown(spec, options);
+    expect(second.skillsSynced).toEqual([]);
+    expect(second.updated).toBe(false);
+  });
+
+  it("returns a top-level error when the index cannot be fetched", async () => {
+    // No index.json route configured → 404
+    const result = await syncWellKnown(spec, options);
+    expect(result.error).toMatch(/Failed to fetch index/);
+    expect(result.skillsSynced).toEqual([]);
+  });
+});

--- a/src/well-known-sync.ts
+++ b/src/well-known-sync.ts
@@ -16,6 +16,7 @@ import * as tar from "tar";
 import * as yauzl from "yauzl-promise";
 import {
   WellKnownSpec,
+  assertUrlAllowed,
   getWellKnownCachePath,
   getWellKnownIndexPath,
   getWellKnownIndexUrl,
@@ -50,6 +51,14 @@ export interface SyncOptions {
   cacheDir: string;
   maxArtifactBytes: number;
   maxUnpackedBytes: number;
+  /**
+   * Allowed publisher origins ("<scheme>://<host>"). Every fetched URL —
+   * index, artifact, and redirect target — must match one of these. Required
+   * so artifacts can't escape the allowlist the index origin was gated by.
+   */
+  allowedOrigins: string[];
+  /** Permit http:// (dev only); otherwise only https:// is fetched. */
+  allowHttp: boolean;
 }
 
 /**
@@ -73,6 +82,7 @@ export interface SyncResult {
 
 const MAX_RETRIES = 3;
 const INITIAL_BACKOFF_MS = 1000;
+const MAX_REDIRECTS = 5;
 
 /**
  * Allowed digest format: sha256:<64 lowercase hex chars>.
@@ -127,56 +137,80 @@ function rmrf(dir: string): void {
  * response headers. Aborts mid-stream if the cumulative byte count exceeds
  * `maxBytes`.
  */
+/**
+ * Read a response body into a Buffer, aborting mid-stream if the cumulative
+ * size exceeds maxBytes. Shared by the artifact fetch and the polling
+ * update-check so every response body is bounded.
+ */
+async function readBodyCapped(
+  response: Response,
+  maxBytes: number,
+  url: string
+): Promise<Buffer> {
+  const reader = response.body?.getReader();
+  if (!reader) {
+    // Body-less response (e.g. HEAD / 304).
+    return Buffer.alloc(0);
+  }
+  const chunks: Buffer[] = [];
+  let total = 0;
+  // eslint-disable-next-line no-constant-condition
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    if (value) {
+      total += value.byteLength;
+      if (total > maxBytes) {
+        try {
+          await reader.cancel();
+        } catch {
+          // ignore
+        }
+        throw new Error(`Response from ${url} exceeds size cap of ${maxBytes} bytes`);
+      }
+      chunks.push(Buffer.from(value));
+    }
+  }
+  return Buffer.concat(chunks);
+}
+
 async function fetchWithRetry(
   url: string,
   init: RequestInit,
-  maxBytes: number
+  maxBytes: number,
+  validateUrl?: (u: string) => void
 ): Promise<{ body: Buffer; headers: Headers; status: number }> {
   let lastError: unknown = undefined;
 
   for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
     try {
-      const response = await fetch(url, init);
+      // Follow redirects manually so each hop's origin/scheme can be
+      // re-validated. fetch's default redirect:"follow" would silently chase a
+      // 3xx off the allowlist, re-opening the SSRF/bypass the allowlist closes.
+      let currentUrl = url;
+      let response = await fetch(currentUrl, { ...init, redirect: "manual" });
+      let hops = 0;
+      while (response.status >= 300 && response.status < 400) {
+        const location = response.headers.get("location");
+        if (!location) break; // e.g. 304 Not Modified — not an actual redirect.
+        if (++hops > MAX_REDIRECTS) {
+          throw new Error(`Too many redirects (>${MAX_REDIRECTS}) starting at ${url}`);
+        }
+        currentUrl = new URL(location, currentUrl).toString();
+        // Throws if the redirect target leaves the allowlist or uses a bad scheme.
+        if (validateUrl) validateUrl(currentUrl);
+        response = await fetch(currentUrl, { ...init, redirect: "manual" });
+      }
 
       if (!response.ok) {
         // 4xx are not retryable; only retry 5xx and network errors.
         if (response.status >= 400 && response.status < 500) {
-          throw new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+          throw new Error(`HTTP ${response.status} ${response.statusText} for ${currentUrl}`);
         }
-        lastError = new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+        lastError = new Error(`HTTP ${response.status} ${response.statusText} for ${currentUrl}`);
       } else {
-        const reader = response.body?.getReader();
-        if (!reader) {
-          // Body-less response (e.g. HEAD). Caller can use status/headers.
-          return { body: Buffer.alloc(0), headers: response.headers, status: response.status };
-        }
-
-        const chunks: Buffer[] = [];
-        let total = 0;
-        // eslint-disable-next-line no-constant-condition
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          if (value) {
-            total += value.byteLength;
-            if (total > maxBytes) {
-              try {
-                await reader.cancel();
-              } catch {
-                // ignore
-              }
-              throw new Error(
-                `Artifact at ${url} exceeds size cap of ${maxBytes} bytes`
-              );
-            }
-            chunks.push(Buffer.from(value));
-          }
-        }
-        return {
-          body: Buffer.concat(chunks),
-          headers: response.headers,
-          status: response.status,
-        };
+        const body = await readBodyCapped(response, maxBytes, currentUrl);
+        return { body, headers: response.headers, status: response.status };
       }
     } catch (error) {
       lastError = error;
@@ -345,6 +379,11 @@ async function extractTarGz(
             `Tar archive contains a ${entryType} (${entry.path}); rejecting for safety`
           );
         }
+        // node-tar fires onentry *before* writing the body, so an oversized
+        // entry is caught pre-write. This trusts the tar header's declared size
+        // (the zip path counts real streamed bytes instead) — acceptable
+        // because the compressed input is already bounded by maxArtifactBytes,
+        // so a lying header can't inflate beyond that gzip blast radius.
         const size = typeof entry.size === "number" ? entry.size : 0;
         unpacked += size;
         if (unpacked > maxUnpackedBytes) {
@@ -392,7 +431,12 @@ async function extractZip(
       if (isUnsafeEntryPath(entryName)) {
         throw new Error(`Zip entry has unsafe path: "${entryName}"`);
       }
-      // Detect symlinks via Unix file mode in external attributes.
+      // Detect symlinks via the Unix file mode packed into the zip's external
+      // file attributes (high 16 bits). Note: if yauzl ever renames this field
+      // the `?? 0` fallback treats entries as non-symlink — but that is not an
+      // escape vector, because a missed symlink entry is written by
+      // writeFileAtomic below as a regular file containing the link *target
+      // string*, never an actual symlink on disk.
       const externalAttrs =
         (entry as unknown as { externalFileAttributes?: number }).externalFileAttributes ?? 0;
       const unixMode = (externalAttrs >>> 16) & 0xffff;
@@ -508,13 +552,19 @@ export async function syncWellKnown(
   ensureDir(cachePath);
   ensureDir(skillsRoot);
 
+  // Re-validate every URL we fetch (index, artifacts, redirect targets) against
+  // the allowlist and scheme rules — not just the configured index origin.
+  const validate = (u: string) => assertUrlAllowed(u, options);
+
   let indexDoc: IndexDocument;
   try {
     const indexUrl = getWellKnownIndexUrl(spec);
+    validate(indexUrl);
     const response = await fetchWithRetry(
       indexUrl,
       { method: "GET", headers: { Accept: "application/json" } },
-      options.maxArtifactBytes
+      options.maxArtifactBytes,
+      validate
     );
     const text = response.body.toString("utf-8");
     const parsed = JSON.parse(text);
@@ -566,10 +616,15 @@ export async function syncWellKnown(
       }
 
       const artifactUrl = resolveArtifactUrl(spec, entry.url);
+      // The entry's url may be absolute/cross-origin — gate it (and any
+      // redirect) on the allowlist before issuing the request, so a malicious
+      // publisher can't point it at an internal host (SSRF) or off-allowlist CDN.
+      validate(artifactUrl);
       const artifactRes = await fetchWithRetry(
         artifactUrl,
         { method: "GET" },
-        options.maxArtifactBytes
+        options.maxArtifactBytes,
+        validate
       );
       verifyDigest(artifactRes.body, entry.digest, `skill "${entry.name}"`);
 
@@ -672,13 +727,19 @@ export async function hasRemoteUpdates(
 
   try {
     const indexUrl = getWellKnownIndexUrl(spec);
-    const res = await fetch(indexUrl, { method: "GET", headers });
+    assertUrlAllowed(indexUrl, options);
+    // redirect:"manual" so a 3xx doesn't wander off-allowlist here; any real
+    // redirect just forces a full sync (which re-validates every hop).
+    const res = await fetch(indexUrl, { method: "GET", headers, redirect: "manual" });
     if (res.status === 304) return false;
+    if (res.status >= 300 && res.status < 400) return true; // redirect → full sync
     if (!res.ok) return true;
 
     // Compare digest of new body to the cached digest as a final tie-breaker.
-    const arr = new Uint8Array(await res.arrayBuffer());
-    const newDigest = sha256Digest(Buffer.from(arr));
+    // Bounded by the same size cap as the main fetch to avoid an unbounded
+    // buffer on every poll.
+    const body = await readBodyCapped(res, options.maxArtifactBytes, indexUrl);
+    const newDigest = sha256Digest(body);
     return newDigest !== meta.digest;
   } catch (error) {
     console.error(

--- a/src/well-known-sync.ts
+++ b/src/well-known-sync.ts
@@ -1,0 +1,689 @@
+/**
+ * Well-known agent skills synchronization.
+ *
+ * Fetches a publisher's `index.json`, verifies SHA-256 digests on every
+ * artifact, and writes verified content into a local cache directory that
+ * the rest of the server treats as a normal skill source.
+ *
+ * Mirrors the contract of github-sync.ts (syncRepo / syncAllRepos /
+ * hasRemoteUpdates), with HTTP fetch + archive extraction in place of git.
+ */
+
+import * as crypto from "node:crypto";
+import * as fs from "node:fs";
+import * as path from "node:path";
+import * as tar from "tar";
+import * as yauzl from "yauzl-promise";
+import {
+  WellKnownSpec,
+  getWellKnownCachePath,
+  getWellKnownIndexPath,
+  getWellKnownIndexUrl,
+  getWellKnownMetaPath,
+  getWellKnownSkillPath,
+  resolveArtifactUrl,
+} from "./well-known-config.js";
+
+/**
+ * One entry in the publisher's discovery index.
+ */
+export interface IndexEntry {
+  name: string;
+  type: "skill-md" | "archive" | string; // Tolerate unknown types so we can skip + warn.
+  description: string;
+  url: string;
+  digest: string;
+}
+
+/**
+ * Parsed discovery index document.
+ */
+export interface IndexDocument {
+  $schema?: string;
+  skills: IndexEntry[];
+}
+
+/**
+ * Options for sync operations.
+ */
+export interface SyncOptions {
+  cacheDir: string;
+  maxArtifactBytes: number;
+  maxUnpackedBytes: number;
+}
+
+/**
+ * Result of a sync operation.
+ */
+export interface SyncResult {
+  spec: WellKnownSpec;
+  /** Path to the directory that contains per-skill subdirectories. */
+  localPath: string;
+  /** Whether any artifact was downloaded or removed since last sync. */
+  updated: boolean;
+  /** Skill names that were successfully written/updated this run. */
+  skillsSynced: string[];
+  /** Skill names that were intentionally pruned. */
+  skillsRemoved: string[];
+  /** Per-skill error messages (does not abort the whole sync). */
+  skillErrors: Record<string, string>;
+  /** Top-level error if the whole sync failed (e.g., index.json fetch). */
+  error?: string;
+}
+
+const MAX_RETRIES = 3;
+const INITIAL_BACKOFF_MS = 1000;
+
+/**
+ * Allowed digest format: sha256:<64 lowercase hex chars>.
+ */
+const DIGEST_RE = /^sha256:[0-9a-f]{64}$/;
+
+/**
+ * Allowed skill name per Agent Skills spec: 1-64 chars, lowercase
+ * alphanumeric and single hyphens, no leading/trailing/consecutive hyphens.
+ */
+const SKILL_NAME_RE = /^[a-z0-9](?:[a-z0-9]|-(?=[a-z0-9])){0,63}$/;
+
+/**
+ * Schema URIs we know how to consume. Other values produce a warning but
+ * the index is still parsed (forward-compat per RFC).
+ */
+const KNOWN_SCHEMAS = new Set<string>([
+  "https://schemas.agentskills.io/discovery/0.2.0/schema.json",
+]);
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function ensureDir(dirPath: string): void {
+  fs.mkdirSync(dirPath, { recursive: true });
+}
+
+/**
+ * Atomically write a buffer to a file (write-then-rename).
+ */
+function writeFileAtomic(filePath: string, data: Buffer | string): void {
+  ensureDir(path.dirname(filePath));
+  const tmpPath = `${filePath}.tmp-${process.pid}-${Date.now()}`;
+  fs.writeFileSync(tmpPath, data);
+  fs.renameSync(tmpPath, filePath);
+}
+
+/**
+ * Recursively remove a directory if it exists.
+ */
+function rmrf(dir: string): void {
+  if (fs.existsSync(dir)) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+/**
+ * Fetch a URL with retry and a hard byte cap.
+ *
+ * Returns the response body (concatenated as a single Buffer) plus the
+ * response headers. Aborts mid-stream if the cumulative byte count exceeds
+ * `maxBytes`.
+ */
+async function fetchWithRetry(
+  url: string,
+  init: RequestInit,
+  maxBytes: number
+): Promise<{ body: Buffer; headers: Headers; status: number }> {
+  let lastError: unknown = undefined;
+
+  for (let attempt = 0; attempt < MAX_RETRIES; attempt++) {
+    try {
+      const response = await fetch(url, init);
+
+      if (!response.ok) {
+        // 4xx are not retryable; only retry 5xx and network errors.
+        if (response.status >= 400 && response.status < 500) {
+          throw new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+        }
+        lastError = new Error(`HTTP ${response.status} ${response.statusText} for ${url}`);
+      } else {
+        const reader = response.body?.getReader();
+        if (!reader) {
+          // Body-less response (e.g. HEAD). Caller can use status/headers.
+          return { body: Buffer.alloc(0), headers: response.headers, status: response.status };
+        }
+
+        const chunks: Buffer[] = [];
+        let total = 0;
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) {
+            total += value.byteLength;
+            if (total > maxBytes) {
+              try {
+                await reader.cancel();
+              } catch {
+                // ignore
+              }
+              throw new Error(
+                `Artifact at ${url} exceeds size cap of ${maxBytes} bytes`
+              );
+            }
+            chunks.push(Buffer.from(value));
+          }
+        }
+        return {
+          body: Buffer.concat(chunks),
+          headers: response.headers,
+          status: response.status,
+        };
+      }
+    } catch (error) {
+      lastError = error;
+    }
+
+    const isLast = attempt === MAX_RETRIES - 1;
+    if (!isLast) {
+      const backoff = INITIAL_BACKOFF_MS * Math.pow(2, attempt);
+      console.error(
+        `Fetch attempt ${attempt + 1}/${MAX_RETRIES} failed for ${url}, retrying in ${backoff}ms...`
+      );
+      await sleep(backoff);
+    }
+  }
+
+  throw lastError instanceof Error ? lastError : new Error(String(lastError));
+}
+
+/**
+ * Compute SHA-256 of a buffer in `sha256:<hex>` form.
+ */
+function sha256Digest(buf: Buffer): string {
+  return "sha256:" + crypto.createHash("sha256").update(buf).digest("hex");
+}
+
+/**
+ * Throw if the actual digest doesn't equal the expected one.
+ */
+function verifyDigest(buf: Buffer, expected: string, label: string): void {
+  if (!DIGEST_RE.test(expected)) {
+    throw new Error(`Malformed digest for ${label}: "${expected}"`);
+  }
+  const actual = sha256Digest(buf);
+  if (actual !== expected) {
+    throw new Error(
+      `Digest mismatch for ${label}: expected ${expected}, got ${actual}`
+    );
+  }
+}
+
+/**
+ * Validate the structural shape of a parsed index document.
+ * Throws on missing/invalid required fields. Per-entry warnings about
+ * unknown `type` values are returned to the caller.
+ */
+export function validateIndexDocument(parsed: unknown): IndexDocument {
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Index is not a JSON object");
+  }
+  const obj = parsed as Record<string, unknown>;
+
+  if (obj.$schema !== undefined && typeof obj.$schema !== "string") {
+    throw new Error("`$schema` field must be a string when present");
+  }
+
+  if (obj.$schema === undefined) {
+    console.error(
+      "Well-known: index has no `$schema` field; treating as v0.1.0 (backward compat)"
+    );
+  } else if (!KNOWN_SCHEMAS.has(obj.$schema)) {
+    console.error(
+      `Well-known: unrecognized $schema "${obj.$schema}"; attempting to parse anyway`
+    );
+  }
+
+  if (!Array.isArray(obj.skills)) {
+    throw new Error("Index `skills` field must be an array");
+  }
+
+  const skills: IndexEntry[] = [];
+  for (const raw of obj.skills) {
+    if (!raw || typeof raw !== "object") {
+      console.error("Well-known: skipping non-object entry in skills array");
+      continue;
+    }
+    const e = raw as Record<string, unknown>;
+    const name = typeof e.name === "string" ? e.name : "";
+    const type = typeof e.type === "string" ? e.type : "";
+    const description = typeof e.description === "string" ? e.description : "";
+    const url = typeof e.url === "string" ? e.url : "";
+    const digest = typeof e.digest === "string" ? e.digest : "";
+
+    if (!name || !type || !description || !url || !digest) {
+      console.error(
+        `Well-known: skipping incomplete entry ${JSON.stringify(name || "<unnamed>")}`
+      );
+      continue;
+    }
+    if (!SKILL_NAME_RE.test(name)) {
+      console.error(`Well-known: skipping entry with invalid name "${name}"`);
+      continue;
+    }
+    if (!DIGEST_RE.test(digest)) {
+      console.error(`Well-known: skipping entry "${name}" with malformed digest`);
+      continue;
+    }
+    skills.push({ name, type, description, url, digest });
+  }
+
+  return { $schema: obj.$schema as string | undefined, skills };
+}
+
+/**
+ * Reject path entries that could escape the destination directory.
+ * Used as a tar `filter` and as a per-entry zip check.
+ */
+function isUnsafeEntryPath(entryPath: string): boolean {
+  if (!entryPath) return true;
+  // Reject absolute paths and Windows drive letters.
+  if (path.isAbsolute(entryPath)) return true;
+  if (/^[a-zA-Z]:/.test(entryPath)) return true;
+  // Normalize and look for traversal.
+  const normalized = entryPath.replace(/\\/g, "/");
+  if (normalized.startsWith("/")) return true;
+  const parts = normalized.split("/");
+  for (const part of parts) {
+    if (part === "..") return true;
+  }
+  return false;
+}
+
+/**
+ * Detect archive format from the URL. Returns null for unrecognized.
+ */
+export function archiveFormatFromUrl(url: string): "tar.gz" | "zip" | null {
+  const lower = url.toLowerCase().split("?")[0].split("#")[0];
+  if (lower.endsWith(".tar.gz") || lower.endsWith(".tgz")) return "tar.gz";
+  if (lower.endsWith(".zip")) return "zip";
+  return null;
+}
+
+/**
+ * Extract a tar.gz archive into `destDir`, with safety checks.
+ *
+ * Rejects: absolute paths, parent traversal, symlinks, hardlinks.
+ * Aborts if cumulative uncompressed bytes exceed `maxUnpackedBytes`.
+ */
+async function extractTarGz(
+  buffer: Buffer,
+  destDir: string,
+  maxUnpackedBytes: number
+): Promise<void> {
+  ensureDir(destDir);
+  // Write to a sibling temp file then extract from disk — `tar.x` with a file
+  // path is the most reliable invocation of the library and lets the kernel
+  // handle streaming.
+  const tmpFile = path.join(destDir, `.archive-${process.pid}-${Date.now()}.tar.gz`);
+  let unpacked = 0;
+  let aborted = false;
+
+  fs.writeFileSync(tmpFile, buffer);
+  try {
+    await tar.x({
+      file: tmpFile,
+      cwd: destDir,
+      strict: true,
+      preservePaths: false,
+      filter: (entryPath: string) => isUnsafeEntryPath(entryPath) ? false : true,
+      onentry: (entry: tar.ReadEntry) => {
+        // Reject symlinks and hardlinks outright — they're ambiguous and
+        // archives almost never need them for an MCP skill.
+        const entryType = (entry as { type?: string }).type;
+        if (entryType === "SymbolicLink" || entryType === "Link") {
+          aborted = true;
+          throw new Error(
+            `Tar archive contains a ${entryType} (${entry.path}); rejecting for safety`
+          );
+        }
+        const size = typeof entry.size === "number" ? entry.size : 0;
+        unpacked += size;
+        if (unpacked > maxUnpackedBytes) {
+          aborted = true;
+          throw new Error(
+            `Tar archive uncompressed size exceeds cap of ${maxUnpackedBytes} bytes`
+          );
+        }
+      },
+    });
+  } finally {
+    try {
+      fs.unlinkSync(tmpFile);
+    } catch {
+      // ignore
+    }
+    if (aborted) {
+      // Wipe partial extraction so a later sync has a clean slate.
+      // (Caller is expected to recreate destDir before next attempt.)
+    }
+  }
+}
+
+/**
+ * Unix mode bits for a symlink in zip external file attributes.
+ */
+const S_IFMT = 0xf000;
+const S_IFLNK = 0xa000;
+
+/**
+ * Extract a zip archive into `destDir`, with safety checks.
+ */
+async function extractZip(
+  buffer: Buffer,
+  destDir: string,
+  maxUnpackedBytes: number
+): Promise<void> {
+  ensureDir(destDir);
+  const zip = await yauzl.fromBuffer(buffer);
+  let unpacked = 0;
+
+  try {
+    for await (const entry of zip) {
+      const entryName = entry.filename;
+      if (isUnsafeEntryPath(entryName)) {
+        throw new Error(`Zip entry has unsafe path: "${entryName}"`);
+      }
+      // Detect symlinks via Unix file mode in external attributes.
+      const externalAttrs =
+        (entry as unknown as { externalFileAttributes?: number }).externalFileAttributes ?? 0;
+      const unixMode = (externalAttrs >>> 16) & 0xffff;
+      if ((unixMode & S_IFMT) === S_IFLNK) {
+        throw new Error(`Zip entry "${entryName}" is a symbolic link; rejecting`);
+      }
+
+      const isDirEntry = entryName.endsWith("/");
+      const targetPath = path.join(destDir, entryName);
+      const resolvedDest = path.resolve(destDir);
+      const resolvedTarget = path.resolve(targetPath);
+      if (!resolvedTarget.startsWith(resolvedDest + path.sep) &&
+          resolvedTarget !== resolvedDest) {
+        throw new Error(`Zip entry "${entryName}" resolves outside the destination`);
+      }
+
+      if (isDirEntry) {
+        ensureDir(targetPath);
+        continue;
+      }
+
+      ensureDir(path.dirname(targetPath));
+      const readStream = await entry.openReadStream();
+      const chunks: Buffer[] = [];
+      let entrySize = 0;
+
+      await new Promise<void>((resolve, reject) => {
+        readStream.on("data", (chunk: Buffer) => {
+          entrySize += chunk.length;
+          unpacked += chunk.length;
+          if (unpacked > maxUnpackedBytes) {
+            readStream.destroy();
+            reject(
+              new Error(
+                `Zip archive uncompressed size exceeds cap of ${maxUnpackedBytes} bytes`
+              )
+            );
+            return;
+          }
+          chunks.push(Buffer.from(chunk));
+        });
+        readStream.on("error", reject);
+        readStream.on("end", resolve);
+      });
+
+      writeFileAtomic(targetPath, Buffer.concat(chunks, entrySize));
+    }
+  } finally {
+    await zip.close();
+  }
+}
+
+/**
+ * Extract an archive (tar.gz or zip) into a destination directory after
+ * digest verification has already passed.
+ */
+async function extractArchive(
+  buffer: Buffer,
+  destDir: string,
+  format: "tar.gz" | "zip",
+  maxUnpackedBytes: number
+): Promise<void> {
+  if (format === "tar.gz") {
+    await extractTarGz(buffer, destDir, maxUnpackedBytes);
+  } else {
+    await extractZip(buffer, destDir, maxUnpackedBytes);
+  }
+}
+
+/**
+ * Load the previously cached index document, if any.
+ * Returns null if the cache is missing or unparseable.
+ */
+function loadCachedIndex(spec: WellKnownSpec, cacheDir: string): IndexDocument | null {
+  const indexPath = getWellKnownIndexPath(spec, cacheDir);
+  if (!fs.existsSync(indexPath)) return null;
+  try {
+    const content = fs.readFileSync(indexPath, "utf-8");
+    const parsed = JSON.parse(content);
+    return validateIndexDocument(parsed);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Sync a single well-known publisher.
+ *
+ * The high-level flow:
+ *   1. Fetch index.json (with retry).
+ *   2. Validate JSON shape and per-entry fields.
+ *   3. For each entry:
+ *        - if cached digest matches and on-disk artifact exists → skip
+ *        - else fetch artifact, verify digest, write/extract atomically
+ *   4. Prune skill subdirectories that are no longer in the index.
+ *   5. Atomically replace the cached index.json.
+ */
+export async function syncWellKnown(
+  spec: WellKnownSpec,
+  options: SyncOptions
+): Promise<SyncResult> {
+  const cachePath = getWellKnownCachePath(spec, options.cacheDir);
+  const skillsRoot = path.join(cachePath, "skills");
+  const result: SyncResult = {
+    spec,
+    localPath: skillsRoot,
+    updated: false,
+    skillsSynced: [],
+    skillsRemoved: [],
+    skillErrors: {},
+  };
+
+  ensureDir(cachePath);
+  ensureDir(skillsRoot);
+
+  let indexDoc: IndexDocument;
+  try {
+    const indexUrl = getWellKnownIndexUrl(spec);
+    const response = await fetchWithRetry(
+      indexUrl,
+      { method: "GET", headers: { Accept: "application/json" } },
+      options.maxArtifactBytes
+    );
+    const text = response.body.toString("utf-8");
+    const parsed = JSON.parse(text);
+    indexDoc = validateIndexDocument(parsed);
+
+    // Persist conditional-fetch hints for later HEAD probes.
+    const meta = {
+      etag: response.headers.get("etag") || null,
+      lastModified: response.headers.get("last-modified") || null,
+      digest: sha256Digest(response.body),
+      fetchedAt: new Date().toISOString(),
+    };
+    writeFileAtomic(getWellKnownMetaPath(spec, options.cacheDir), JSON.stringify(meta, null, 2));
+  } catch (error) {
+    const msg = error instanceof Error ? error.message : String(error);
+    result.error = `Failed to fetch index for ${spec.origin}: ${msg}`;
+    console.error(result.error);
+    return result;
+  }
+
+  const cached = loadCachedIndex(spec, options.cacheDir);
+  const cachedByName = new Map<string, IndexEntry>();
+  if (cached) {
+    for (const e of cached.skills) cachedByName.set(e.name, e);
+  }
+
+  const newNames = new Set<string>();
+
+  for (const entry of indexDoc.skills) {
+    newNames.add(entry.name);
+    const skillDir = getWellKnownSkillPath(spec, entry.name, options.cacheDir);
+
+    try {
+      if (entry.type !== "skill-md" && entry.type !== "archive") {
+        console.error(
+          `Well-known: skipping skill "${entry.name}" with unrecognized type "${entry.type}"`
+        );
+        continue;
+      }
+
+      const skillMdPath = path.join(skillDir, "SKILL.md");
+      const cachedEntry = cachedByName.get(entry.name);
+      const digestUnchanged = cachedEntry?.digest === entry.digest;
+      const artifactPresent = fs.existsSync(skillMdPath);
+
+      if (digestUnchanged && artifactPresent) {
+        // Up to date.
+        continue;
+      }
+
+      const artifactUrl = resolveArtifactUrl(spec, entry.url);
+      const artifactRes = await fetchWithRetry(
+        artifactUrl,
+        { method: "GET" },
+        options.maxArtifactBytes
+      );
+      verifyDigest(artifactRes.body, entry.digest, `skill "${entry.name}"`);
+
+      // Wipe previous skill dir to avoid stale supporting files.
+      rmrf(skillDir);
+      ensureDir(skillDir);
+
+      if (entry.type === "skill-md") {
+        writeFileAtomic(skillMdPath, artifactRes.body);
+      } else {
+        // archive
+        const format = archiveFormatFromUrl(artifactUrl);
+        if (!format) {
+          throw new Error(
+            `Archive entry "${entry.name}" has unsupported file extension: ${artifactUrl}`
+          );
+        }
+        await extractArchive(artifactRes.body, skillDir, format, options.maxUnpackedBytes);
+        if (!fs.existsSync(skillMdPath)) {
+          throw new Error(
+            `Archive for "${entry.name}" did not contain SKILL.md at the root`
+          );
+        }
+      }
+
+      result.skillsSynced.push(entry.name);
+      result.updated = true;
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : String(error);
+      result.skillErrors[entry.name] = msg;
+      console.error(`Well-known: failed to sync "${entry.name}": ${msg}`);
+      // Discard partially-written content so subsequent reads don't see it.
+      rmrf(skillDir);
+    }
+  }
+
+  // Prune skill subdirectories that disappeared from the index.
+  if (cached) {
+    for (const e of cached.skills) {
+      if (!newNames.has(e.name)) {
+        const dir = getWellKnownSkillPath(spec, e.name, options.cacheDir);
+        rmrf(dir);
+        result.skillsRemoved.push(e.name);
+        result.updated = true;
+      }
+    }
+  }
+
+  // Persist the new index last so a crash mid-sync leaves the old index in
+  // place (digest comparison on the next run will redo any incomplete work).
+  writeFileAtomic(
+    getWellKnownIndexPath(spec, options.cacheDir),
+    JSON.stringify(indexDoc, null, 2)
+  );
+
+  return result;
+}
+
+/**
+ * Sync multiple publishers sequentially.
+ */
+export async function syncAllWellKnown(
+  specs: WellKnownSpec[],
+  options: SyncOptions
+): Promise<SyncResult[]> {
+  const results: SyncResult[] = [];
+  for (const spec of specs) {
+    results.push(await syncWellKnown(spec, options));
+  }
+  return results;
+}
+
+/**
+ * Cheaply check whether the publisher's index has changed.
+ *
+ * Strategy:
+ *   1. If we have no cached meta, return true (force full sync).
+ *   2. Send a conditional GET (If-None-Match / If-Modified-Since). 304 → no
+ *      change; 200 → new body, compare digests.
+ *
+ * This avoids hashing on the publisher's side and keeps bandwidth low.
+ */
+export async function hasRemoteUpdates(
+  spec: WellKnownSpec,
+  options: SyncOptions
+): Promise<boolean> {
+  const metaPath = getWellKnownMetaPath(spec, options.cacheDir);
+  if (!fs.existsSync(metaPath)) return true;
+
+  let meta: { etag: string | null; lastModified: string | null; digest: string | null };
+  try {
+    meta = JSON.parse(fs.readFileSync(metaPath, "utf-8"));
+  } catch {
+    return true;
+  }
+
+  const headers: Record<string, string> = { Accept: "application/json" };
+  if (meta.etag) headers["If-None-Match"] = meta.etag;
+  if (meta.lastModified) headers["If-Modified-Since"] = meta.lastModified;
+
+  try {
+    const indexUrl = getWellKnownIndexUrl(spec);
+    const res = await fetch(indexUrl, { method: "GET", headers });
+    if (res.status === 304) return false;
+    if (!res.ok) return true;
+
+    // Compare digest of new body to the cached digest as a final tie-breaker.
+    const arr = new Uint8Array(await res.arrayBuffer());
+    const newDigest = sha256Digest(Buffer.from(arr));
+    return newDigest !== meta.digest;
+  } catch (error) {
+    console.error(
+      `Well-known: update check failed for ${spec.origin}: ${error instanceof Error ? error.message : error}`
+    );
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary

- Adds **consumer-side** support for the [agent-skills discovery RFC](https://github.com/cloudflare/agent-skills-discovery-rfc) (v0.2.0). Skilljack can now pull skills from any HTTPS publisher serving `/.well-known/agent-skills/index.json`, alongside existing local + GitHub sources.
- Every artifact is **SHA-256 verified** against the publisher's index entry; mismatches are rejected before anything is written to disk.
- Both `skill-md` (single SKILL.md) and `archive` (`.tar.gz` / `.zip`) entry types are supported, with safety checks for path traversal, symlinks, decompression bombs, and an enforced size cap.
- Mirrors the existing GitHub source: default-deny allowlist (`WELL_KNOWN_ALLOWED_ORIGINS`), 5-min polling with ETag-driven conditional refetch, per-publisher cache directory, prune-on-removal.

## What's new

| Area | What changed |
|---|---|
| `src/well-known-config.ts` | URL detection (`isWellKnownUrl`), normalization (auto-appends `/.well-known/agent-skills`), allowlist (`isOriginAllowed`), cache-path helpers, env-var config |
| `src/well-known-sync.ts` | `syncWellKnown` orchestrates fetch → validate → digest-verify → write/extract; safe `tar`/`yauzl-promise` extraction; index pruning; conditional refresh via ETag |
| `src/well-known-polling.ts` | Polling manager with the same shape as `github-polling.ts` |
| `src/index.ts` | Third bucket in `classifyPaths`, well-known sync at startup + on UI refresh, second polling manager |
| `src/skill-config.ts` / `src/skill-discovery.ts` / `src/skill-display-tool.ts` | `SourceType` and `SkillSource.type` extended with `\"well-known\"` |
| `src/ui/skill-display.{ts,css}` | New source badge for well-known publishers |
| `src/ui/mcp-app.{ts,html}` | Directory type union widened; blocked-state check now covers well-known too; add-directory placeholder/help text mention the URL form |
| `package.json` | `tar` + `yauzl-promise` (with a small ambient `.d.ts` since the latter ships no types). Bumped to `0.12.0`. |
| `README.md` / `CLAUDE.md` | Usage example + new env vars + architecture notes |

## Configuration

```bash
WELL_KNOWN_ALLOWED_ORIGINS=https://example.com \
  skilljack-mcp https://example.com/.well-known/agent-skills/
```

Other env vars: `WELL_KNOWN_POLL_INTERVAL_MS` (default 300000), `WELL_KNOWN_MAX_ARTIFACT_MB` (10), `WELL_KNOWN_MAX_UNPACKED_MB` (50), `WELL_KNOWN_ALLOW_HTTP` (dev only).

## Tests

28 new tests across `well-known-{config,sync,polling}.test.ts` use a local `http.createServer` fixture (no network). They cover:

- URL parsing / normalization / allowlist gating
- Index shape validation (`$schema` versioning, malformed digests, invalid skill names, unknown `type` values)
- `skill-md` happy path + digest mismatch rejection + size-cap rejection
- `tar.gz` archive happy path (multi-file)
- `tar.gz` archive missing `SKILL.md` rejection
- `tar.gz` archive with `../escape` path-traversal entry rejection
- Pruning per-skill cache dirs when a skill is removed from the index
- Idempotent re-sync (no work when digests unchanged)
- Top-level error when `index.json` cannot be fetched
- Polling: `onUpdate` fires only when the index actually changes; timer doesn't start when interval ≤ 0 or no specs

Full suite: **217 / 217 passing**, build clean.

## Out of scope (intentional)

A full UI for managing the well-known origin allowlist (parallel to the existing \"Allowed Orgs\" panel) is **deferred to a follow-up PR** — it would add new server tools, a new HTML panel, and ~300 LOC of UI code best reviewed on its own. For now, configure via `WELL_KNOWN_ALLOWED_ORIGINS` or `~/.skilljack/config.json`.

Publisher-mode (this server *exposing* its skills at `.well-known/agent-skills/`) is also out of scope; `buildSkillIndex()` already produces the right document shape, but no HTTP transport is added.

## Test plan

- [ ] `npm install`, `npm run build`, `npm test` — all green locally.
- [ ] Spin up a local HTTPS publisher (or use the test fixtures) and add it via `WELL_KNOWN_ALLOWED_ORIGINS=… npm run inspector https://…/.well-known/agent-skills/`.
- [ ] Verify skills appear in `tools/list`, `prompts/list`, and `skill://…/SKILL.md` resources.
- [ ] Modify the publisher's `SKILL.md` + bump its digest in `index.json`; confirm `notifications/tools/list_changed` fires within 5 minutes.
- [ ] Confirm a digest-tampered artifact is rejected (logs an error, skill is not written).
- [ ] Confirm an origin not on the allowlist is reported as blocked at startup.
- [ ] Confirm an archive entry with `..` is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)