### PR TITLE
Add minimal CI workflow (build + test)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,20 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - run: npm ci
+      - run: npm run build
+      - run: npm test


### PR DESCRIPTION
Adds a GitHub Actions workflow that runs `npm ci`, `npm run build`, and `npm test` on Node 20 for pushes to `main` and every PR targeting `main`.

The repo had no CI, so passing-test claims on PRs (#63, #64) weren't verified by automation. This closes that gap. Once merged, rebasing open PR branches onto main enables checks on them too.

Related: #47 (add unit tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)