### PR TITLE
Stateless HTTP transport + fix MCP-mode evals for agent-sdk 0.3.x tool search

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,6 +175,7 @@ The resource layer follows [SEP-2640 (Skills Extension)](https://github.com/mode
 ## Conventions
 
 - ES modules (`.js` extensions in imports)
+- **Tool search / deferred tools limitation:** the skill catalog lives in the `load-skill` tool *description* (`getToolDescription`). Clients with tool search / deferred tool loading enabled (default on modern Claude Code) defer MCP tool descriptions out of context, so the model never sees the catalog and won't auto-activate — activation needs `ENABLE_TOOL_SEARCH=false`. Do NOT "fix" this by also stuffing the catalog into server `instructions`: instructions (static) and the tool description (dynamic) are deliberately independent, and `instructions` is becoming more optional in the spec. Making the dynamic catalog work under tool search is an open product problem (tracking issue).
 - Transports: stdio (default, full dynamic refresh + UI config/display tools) or stateless HTTP (`--http`, core skill surface only, per-request `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`, no push notifications). `main()` branches to `startHttpServer()` right after startup discovery.
 - Errors logged to stderr (stdout is MCP protocol)
 - Security: path traversal checks via `isPathWithinBase()`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,10 +20,12 @@ CI (`.github/workflows/ci.yml`) runs `npm ci`, `npm run build`, and `npm test` o
 - `WELL_KNOWN_MAX_ARTIFACT_MB` - Per-artifact byte cap (default 10)
 - `WELL_KNOWN_MAX_UNPACKED_MB` - Archive uncompressed size cap (default 50)
 - `WELL_KNOWN_ALLOW_HTTP` - `1`/`true`/`yes` to permit `http://` origins (dev only)
+- `SKILLJACK_HTTP_PORT` / `SKILLJACK_HTTP` - Serve over stateless HTTP instead of stdio (port, default 3000)
 
 **CLI Options:**
 - Positional args: Skill directories, GitHub URLs, or well-known publisher URLs (e.g. `https://example.com/.well-known/agent-skills/`)
 - `--static`: Enable static mode (freeze skills at startup, no file watching)
+- `--http` / `--http=<port>`: Serve over stateless Streamable HTTP at `POST /mcp` instead of stdio (single token so it isn't parsed as a skill dir)
 
 ## Project Structure
 
@@ -44,6 +46,7 @@ src/
 ├── well-known-config.ts   # Well-known URL detection, parsing, allowlist, URL validation
 ├── well-known-sync.ts     # Fetch + verify (SHA-256) + safely extract publisher artifacts
 ├── well-known-polling.ts  # Periodic well-known index re-fetch (ETag/If-None-Match)
+├── http-transport.ts      # Stateless Streamable HTTP transport (buildCoreServer, startHttpServer)
 ├── types/                 # Ambient type declarations (e.g. yauzl-promise)
 └── ui/                    # MCP Apps UI (mcp-app.ts, skill-display.ts) built by Vite
 ```
@@ -172,6 +175,7 @@ The resource layer follows [SEP-2640 (Skills Extension)](https://github.com/mode
 ## Conventions
 
 - ES modules (`.js` extensions in imports)
+- Transports: stdio (default, full dynamic refresh + UI config/display tools) or stateless HTTP (`--http`, core skill surface only, per-request `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`, no push notifications). `main()` branches to `startHttpServer()` right after startup discovery.
 - Errors logged to stderr (stdout is MCP protocol)
 - Security: path traversal checks via `isPathWithinBase()`
 - File size limit: 1MB default (`MAX_FILE_SIZE_MB` env var to configure)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 An MCP server that jacks [Agent Skills](https://agentskills.io) directly into your LLM's brain.
 
+> ⚠️ **Heads up — tool search / deferred tools.** Skilljack surfaces its skill catalog through the `load-skill` **tool description**. Clients with **tool search / deferred tool loading** on (the default on modern Claude Code) don't load MCP tool descriptions into context up front, so the model won't reliably auto-activate skilljack skills. Set `ENABLE_TOOL_SEARCH=false` to use automatic activation today. Working with tool search enabled is an open item.
+
 ## Installation
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -48,7 +48,13 @@ SKILLS_DIR=/path/to/skills skilljack-mcp
 
 # Static mode (no file watching)
 skilljack-mcp --static /path/to/skills
+
+# Serve over HTTP instead of stdio (stateless Streamable HTTP on POST /mcp)
+skilljack-mcp --http=3000 /path/to/skills
+# or: SKILLJACK_HTTP_PORT=3000 skilljack-mcp /path/to/skills
 ```
+
+**Transports:** stdio (default) or stateless HTTP (`--http[=port]`, default `3000`, or `SKILLJACK_HTTP_PORT`). HTTP serves the core skill surface (`load-skill`, `skill-resource`, `skill://` resources, `/skill` prompts) at `POST /mcp`. Because it is stateless, it does not push `listChanged`/`resources/updated` notifications — skills are read at startup; restart to pick up changes. Use stdio for the dynamic-refresh and MCP-Apps UI features.
 
 ## Configuration and Skills Display UI
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -16,6 +16,15 @@ npm install
 npm run build
 ```
 
+## MCP-mode setup (important)
+
+On agent-sdk 0.3.x, MCP-mode evals only measure skill activation meaningfully after working around **two independent regressions** (the harness does this automatically — see `lib/options-builder.ts`):
+
+1. **stdio connect race** — the SDK connects stdio MCP servers *asynchronously*, so a stdio skilljack is still `pending` at the model's first turn and its tools are absent (upstream [anthropics/claude-code#49753](https://github.com/anthropics/claude-code/issues/49753)). The harness runs skilljack over **HTTP** (`--http=0`, ephemeral port) instead of stdio so it is `connected` on turn 1.
+2. **tool search / deferred tools** — MCP tool *descriptions* are deferred out of context, so the model never sees skilljack's `<available_skills>` catalog (which lives in the `load-skill` tool description) and won't activate. The harness sets **`ENABLE_TOOL_SEARCH=false`** so all tool definitions load into context every turn.
+
+**Product caveat:** #2 means skilljack's catalog-in-the-tool-description approach only surfaces to the model when tool search is disabled. On a default modern Claude Code (tool search on), auto-activation of MCP-delivered skills is unreliable — see the disclaimer in the main docs and the tracking issue.
+
 ## Running Evals
 
 ```bash

--- a/evals/eval.ts
+++ b/evals/eval.ts
@@ -9,7 +9,7 @@ import {
   SessionLogger
 } from "./lib/metrics.js";
 import { analyzeSession, printEvalResult, EvalConfig } from "./lib/eval-checker.js";
-import { buildOptions, cleanupLocalSkills, EvalMode } from "./lib/options-builder.js";
+import { buildOptions, cleanupLocalSkills, cleanupEvalServers, EvalMode } from "./lib/options-builder.js";
 
 interface CLIArgs {
   task: string;
@@ -332,6 +332,9 @@ async function main() {
     if (mode === "local" || mode === "cli-local" || mode === "mcp+local") {
       await cleanupLocalSkills();
     }
+
+    // Tear down any skilljack HTTP servers spawned for MCP-mode evals.
+    cleanupEvalServers();
 
     if (error) {
       throw error;

--- a/evals/lib/options-builder.ts
+++ b/evals/lib/options-builder.ts
@@ -1,8 +1,76 @@
 // Options builder for skill evals
 import * as path from "path";
 import * as fs from "fs/promises";
+import { spawn, ChildProcess } from "child_process";
 
 export type EvalMode = "mcp" | "local" | "cli-local" | "mcp+local";
+
+/**
+ * skilljack HTTP servers spawned for MCP-mode evals. Tracked so eval.ts can
+ * tear them down after each run via cleanupEvalServers().
+ */
+const spawnedHttpServers: ChildProcess[] = [];
+
+/**
+ * Start skilljack over stateless HTTP on an ephemeral port and resolve its
+ * `POST /mcp` URL once it is ready.
+ *
+ * MCP-mode evals use HTTP (not stdio) so the server is `connected` on the
+ * model's first turn — the agent-sdk 0.3.x stdio connect race leaves a
+ * stdio server `pending` and its tools absent turn 1. See evals/README.md.
+ */
+async function startSkilljackHttp(skillsDir: string): Promise<string> {
+  const serverPath = path.resolve("./dist/index.js");
+  try {
+    await fs.access(serverPath);
+  } catch {
+    throw new Error(`Skilljack MCP server not found at ${serverPath}. Run 'npm run build' first.`);
+  }
+  const absoluteSkillsDir = path.resolve(skillsDir);
+  const proc = spawn("node", [serverPath, "--http=0", absoluteSkillsDir], {
+    stdio: ["ignore", "ignore", "pipe"],
+  });
+  spawnedHttpServers.push(proc);
+
+  return await new Promise<string>((resolve, reject) => {
+    const timeout = setTimeout(() => reject(new Error("skilljack HTTP start timeout")), 15000);
+    let buf = "";
+    proc.stderr!.on("data", (d) => {
+      buf += String(d);
+      const m = buf.match(/http:\/\/localhost:(\d+)\/mcp/);
+      if (m) {
+        clearTimeout(timeout);
+        resolve(`http://127.0.0.1:${m[1]}/mcp`);
+      }
+    });
+    proc.on("exit", (code) => {
+      clearTimeout(timeout);
+      reject(new Error(`skilljack HTTP server exited early (code ${code})`));
+    });
+  });
+}
+
+/** Kill any skilljack HTTP servers spawned for evals. Call in eval.ts finally. */
+export function cleanupEvalServers(): void {
+  for (const proc of spawnedHttpServers) {
+    try {
+      proc.kill();
+    } catch {
+      // already gone
+    }
+  }
+  spawnedHttpServers.length = 0;
+}
+
+/**
+ * ENABLE_TOOL_SEARCH=false loads all tool definitions (incl. skilljack's
+ * load-skill tool description, which carries the <available_skills> catalog)
+ * into context every turn. With tool search ON (default), MCP tool descriptions
+ * are DEFERRED out of context, so the model never sees the skill catalog and
+ * won't activate. Skilljack's catalog-in-tool-description method requires this
+ * to be off. See evals/README.md.
+ */
+const TOOL_SEARCH_OFF_ENV = { ENABLE_TOOL_SEARCH: "false" as const };
 
 export interface BuildOptionsConfig {
   mode: EvalMode;
@@ -111,19 +179,19 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
   // A minimal string prompt is used for all modes (not the `claude_code`
   // preset).
   //
-  // KNOWN ISSUE — MCP-mode activation on agent-sdk 0.3.x:
-  // In MCP mode the model frequently fails to call the skilljack skill tool.
-  // Root cause (verified 2026-07-05 via an init-message probe + a controlled
-  // 2x2): agent-sdk 0.3.x connects stdio MCP servers *asynchronously*, so the
-  // skilljack server is still `pending` at the SDK init message and its tools
-  // are absent from the tool list the model sees on its first turn — the model
-  // answers directly before skilljack finishes connecting. On 0.1.x the server
-  // connected synchronously before the first turn and activation worked.
-  // It is NOT the system prompt, NOT the `claude_code` preset (forcing the
-  // preset on 0.3.x still fails to activate), and NOT allowedTools. Local/native
-  // mode is unaffected because the native Skill tool is present on turn 1.
-  // Fix options: pin evals to a 0.1.x SDK, wait for MCP connection before the
-  // first query if the SDK exposes a hook, or fix upstream.
+  // MCP-mode activation on agent-sdk 0.3.x required working around TWO
+  // independent regressions (verified 2026-07-05 by controlled experiments):
+  //   A) stdio connect race — the SDK connects stdio MCP servers asynchronously,
+  //      so a stdio skilljack is still `pending` at init and its tools are absent
+  //      on the model's first turn (upstream anthropics/claude-code#49753).
+  //      → Fixed here by running skilljack over HTTP (startSkilljackHttp), which
+  //        is `connected` on turn 1.
+  //   B) tool search / deferred tools — MCP tool DESCRIPTIONS are deferred out of
+  //      context, so the model never sees skilljack's <available_skills> catalog
+  //      (which lives in the load-skill tool description) and won't activate.
+  //      → Fixed here by ENABLE_TOOL_SEARCH=false (TOOL_SEARCH_OFF_ENV).
+  // Both are needed together for clean activation. It is NOT the system prompt,
+  // NOT the claude_code preset, and NOT allowedTools.
   const MINIMAL_SYSTEM_PROMPT =
     "You are a helpful assistant. Use the tools available to you to complete the user's request.";
   const effectiveSystemPrompt = systemPrompt
@@ -156,63 +224,47 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
       settingSources: ['project' as const],
       allowedTools: ["Bash", "Read", "Write", "Skill"],
       permissionMode: "default" as const,
-      model: modelId
+      model: modelId,
+      // Uniform tool visibility across modes (the native Skill tool can also be
+      // deferred under tool search); keeps cross-mode comparisons apples-to-apples.
+      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
     };
   } else if (mode === "mcp+local") {
-    // Combined mode: both MCP server AND local skills enabled
-    // Tests behavior when both skill delivery mechanisms are available
+    // Combined mode: both MCP server (over HTTP) AND local skills enabled.
+    // Tests which delivery the agent prefers when both are available.
     await setupLocalSkills(skillsDir);
     await ensureSettingsJson();
 
-    const absoluteSkillsDir = path.resolve(skillsDir);
-    const serverPath = path.resolve('./dist/index.js');
-
-    // Verify server exists
-    try {
-      await fs.access(serverPath);
-    } catch {
-      throw new Error(`Skilljack MCP server not found at ${serverPath}. Run 'npm run build' first.`);
-    }
+    const url = await startSkilljackHttp(skillsDir);
 
     options = {
       cwd: process.cwd(),
       mcpServers: {
-        skilljack: {
-          command: "node",
-          args: [serverPath, absoluteSkillsDir]
-        }
+        skilljack: { type: "http" as const, url }
       },
       systemPrompt: effectiveSystemPrompt,
       settingSources: ['project' as const],
       // Allow both MCP and local skill tools
       allowedTools: ["Bash", "Read", "Write", "Skill", "mcp__skilljack"],
       permissionMode: "default" as const,
-      model: modelId
+      model: modelId,
+      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
     };
   } else {
-    // MCP mode: use skilljack server only
-    const absoluteSkillsDir = path.resolve(skillsDir);
-    const serverPath = path.resolve('./dist/index.js');
-
-    // Verify server exists
-    try {
-      await fs.access(serverPath);
-    } catch {
-      throw new Error(`Skilljack MCP server not found at ${serverPath}. Run 'npm run build' first.`);
-    }
+    // MCP mode: skilljack over HTTP (avoids the stdio connect race, regression A)
+    // + tool search off (surfaces the tool-description catalog, regression B).
+    const url = await startSkilljackHttp(skillsDir);
 
     options = {
       cwd: process.cwd(),
       mcpServers: {
-        skilljack: {
-          command: "node",
-          args: [serverPath, absoluteSkillsDir]
-        }
+        skilljack: { type: "http" as const, url }
       },
       systemPrompt: effectiveSystemPrompt,
       allowedTools: ["mcp__skilljack"],
       permissionMode: "default" as const,
-      model: modelId
+      model: modelId,
+      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
     };
   }
 

--- a/skills/skilljack-docs/SKILL.md
+++ b/skills/skilljack-docs/SKILL.md
@@ -9,6 +9,8 @@ An MCP server that jacks [Agent Skills](https://agentskills.io) directly into yo
 
 > **Recommended:** For best results, use an MCP client that supports `tools/listChanged` notifications (e.g., Claude Code). This enables dynamic skill discovery - when skills are added or modified, the client automatically refreshes its understanding of available skills. Alternatively, use `--static` mode for predictable behavior with a fixed skill set.
 
+> ⚠️ **Tool search / deferred tools limitation.** Skilljack delivers its skill catalog inside the `load-skill` **tool description**. Clients with **tool search / deferred tool loading** enabled (the default on modern Claude Code, ~2.1.x) do **not** load MCP tool descriptions into the model's context up front — they are discovered on demand — so the model does not see the `<available_skills>` catalog and will **not reliably auto-activate** skilljack skills. To use skilljack's automatic activation today, **disable tool search** (e.g. `ENABLE_TOOL_SEARCH=false`). Making skilljack work with tool search enabled is an open item ([tracking issue](https://github.com/olaservo/skilljack-mcp/issues)).
+
 ## Features
 
 - **Dynamic Skill Discovery** - Watches skill directories and automatically refreshes when skills change

--- a/skills/skilljack-docs/SKILL.md
+++ b/skills/skilljack-docs/SKILL.md
@@ -95,6 +95,16 @@ Use static mode when you need predictable behavior or have a fixed set of skills
 skilljack-mcp "C:/Users/you/skills"
 ```
 
+### HTTP Transport
+
+By default skilljack communicates over **stdio**. To serve over **stateless Streamable HTTP** instead, use `--http` (or `SKILLJACK_HTTP_PORT`):
+
+```bash
+skilljack-mcp --http=3000 /path/to/skills
+```
+
+Clients connect at `POST /mcp`. HTTP mode serves the core skill surface — `load-skill`, `skill-resource`, `skill://` resources, and `/skill` prompts. Because it is stateless (no session, no server→client stream), it does **not** send `listChanged` / `resources/updated` notifications, and the UI config/display tools are stdio-only. Skills are read at startup; restart to pick up on-disk changes. Use stdio when you need dynamic refresh or the configuration UI.
+
 ## Configuration UI
 
 In MCP clients that support [MCP Apps](https://blog.modelcontextprotocol.io/posts/2026-01-26-mcp-apps/) (like Claude Desktop), you can manage skill directories through an interactive UI.

--- a/src/http-transport.test.ts
+++ b/src/http-transport.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from "vitest";
+import * as path from "node:path";
+import type * as http from "node:http";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { startHttpServer } from "./http-transport.js";
+import { createTestSkill, createTestSkillState } from "./__test-helpers__/helpers.js";
+import { BUNDLED_SKILL_SOURCE } from "./skill-discovery.js";
+
+const FIXTURES_DIR = path.resolve(__dirname, "__fixtures__", "skills");
+
+function portOf(server: http.Server): number {
+  const addr = server.address();
+  return typeof addr === "object" && addr ? addr.port : 0;
+}
+
+describe("stateless HTTP transport", () => {
+  it("serves the core skill surface (tools + resources) over Streamable HTTP", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+    const state = createTestSkillState([
+      createTestSkill({
+        name: "test-skill",
+        baseName: "test-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+
+    const server = await startHttpServer(0, state);
+    const client = new Client({ name: "test-client", version: "0.0.1" });
+    const transport = new StreamableHTTPClientTransport(
+      new URL(`http://127.0.0.1:${portOf(server)}/mcp`)
+    );
+
+    try {
+      await client.connect(transport);
+
+      const tools = await client.listTools();
+      const toolNames = tools.tools.map((t) => t.name);
+      expect(toolNames).toContain("load-skill");
+      expect(toolNames).toContain("skill-resource");
+
+      const resources = await client.listResources();
+      const uris = resources.resources.map((r) => r.uri);
+      expect(uris).toContain("skill://test-skill/SKILL.md");
+    } finally {
+      await client.close().catch(() => {});
+      await transport.close().catch(() => {});
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  it("rejects non-POST requests", async () => {
+    const state = createTestSkillState([]);
+    const server = await startHttpServer(0, state);
+    try {
+      const res = await fetch(`http://127.0.0.1:${portOf(server)}/mcp`, { method: "GET" });
+      expect(res.status).toBe(405);
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+});

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -1,0 +1,100 @@
+/**
+ * Stateless (sessionless) HTTP transport for skilljack.
+ *
+ * Serves the core skill surface (load-skill, skill-resource, skill:// resources,
+ * and /skill prompts) over Streamable HTTP. Each POST /mcp is handled by a
+ * fresh McpServer + StreamableHTTPServerTransport with `sessionIdGenerator:
+ * undefined` (the SDK's stateless mode), so no session state is retained
+ * between requests.
+ *
+ * Limitation: stateless mode has no server->client stream, so listChanged /
+ * resources/updated notifications are not delivered. Skills are read from the
+ * skillState captured at startup; restart to pick up on-disk changes. The
+ * default stdio transport keeps full dynamic-refresh behavior.
+ */
+
+import * as http from "node:http";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import { registerSkillTool, SkillState } from "./skill-tool.js";
+import { registerSkillResources } from "./skill-resources.js";
+import { registerSkillPrompts } from "./skill-prompts.js";
+import { generateInstructions, getModelInvocableSkills } from "./skill-discovery.js";
+
+/**
+ * Build a fresh McpServer exposing the core skill surface for one request.
+ *
+ * listChanged/subscribe are advertised as false: stateless HTTP cannot push
+ * notifications, so promising them would be dishonest.
+ */
+export function buildCoreServer(skillState: SkillState): McpServer {
+  const skills = Array.from(skillState.skillMap.values());
+  const instructions = generateInstructions(getModelInvocableSkills(skills));
+
+  const server = new McpServer(
+    { name: "skilljack-mcp", version: "1.0.0" },
+    {
+      capabilities: {
+        tools: { listChanged: false },
+        resources: { subscribe: false, listChanged: false },
+        prompts: { listChanged: false },
+        // SEP-2640 (Skills Extension)
+        extensions: {
+          "io.modelcontextprotocol/skills": {},
+        },
+      },
+      instructions,
+    }
+  );
+
+  registerSkillTool(server, skillState);
+  registerSkillResources(server, skillState);
+  registerSkillPrompts(server, skillState);
+
+  return server;
+}
+
+const JSONRPC_ERROR = (code: number, message: string) =>
+  JSON.stringify({ jsonrpc: "2.0", error: { code, message }, id: null });
+
+/**
+ * Start a stateless Streamable HTTP MCP server on the given port.
+ * Resolves with the listening http.Server once it is accepting connections.
+ */
+export async function startHttpServer(port: number, skillState: SkillState): Promise<http.Server> {
+  const httpServer = http.createServer(async (req, res) => {
+    const url = req.url ?? "";
+    if (req.method !== "POST" || !(url === "/mcp" || url.startsWith("/mcp?"))) {
+      res.writeHead(405, { "Content-Type": "application/json", Allow: "POST" });
+      res.end(JSONRPC_ERROR(-32000, "Only POST /mcp is supported (stateless mode)"));
+      return;
+    }
+
+    // Fresh server + transport per request (stateless).
+    const server = buildCoreServer(skillState);
+    const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
+    res.on("close", () => {
+      transport.close();
+      server.close();
+    });
+
+    try {
+      await server.connect(transport);
+      let body = "";
+      for await (const chunk of req) body += chunk;
+      await transport.handleRequest(req, res, body ? JSON.parse(body) : undefined);
+    } catch (err) {
+      console.error("HTTP MCP request error:", err);
+      if (!res.headersSent) {
+        res.writeHead(500, { "Content-Type": "application/json" });
+        res.end(JSONRPC_ERROR(-32603, "Internal server error"));
+      }
+    }
+  });
+
+  await new Promise<void>((resolve) => httpServer.listen(port, resolve));
+  const addr = httpServer.address();
+  const boundPort = typeof addr === "object" && addr ? addr.port : port;
+  console.error(`Skilljack ready on http://localhost:${boundPort}/mcp (stateless HTTP). I know kung fu.`);
+  return httpServer;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -31,6 +31,7 @@ import { discoverSkills, createSkillMap, applyInvocationOverrides, SkillSource, 
 import { registerSkillTool, getToolDescription, SkillState } from "./skill-tool.js";
 import { registerSkillResources } from "./skill-resources.js";
 import { registerSkillPrompts, refreshPrompts, PromptRegistry } from "./skill-prompts.js";
+import { startHttpServer } from "./http-transport.js";
 import {
   createSubscriptionManager,
   registerSubscriptionHandlers,
@@ -215,6 +216,34 @@ export function getStaticMode(): boolean {
 
   // Check config file (lowest priority)
   return getStaticModeFromConfig();
+}
+
+/**
+ * Resolve the HTTP port if HTTP transport is requested, else null (stdio).
+ *
+ * Enabled via `--http` / `--http=<port>` (single token so it isn't parsed as a
+ * skill directory) or `SKILLJACK_HTTP_PORT` / `SKILLJACK_HTTP`. Precedence for
+ * the port: `--http=<port>` > `SKILLJACK_HTTP_PORT` > default 3000.
+ */
+export function getHttpPort(): number | null {
+  const args = process.argv.slice(2);
+  const flag = args.find((a) => a === "--http" || a.startsWith("--http="));
+  const envPortRaw = process.env.SKILLJACK_HTTP_PORT;
+  const envToggle = process.env.SKILLJACK_HTTP?.toLowerCase();
+  const envEnabled =
+    !!envPortRaw || envToggle === "true" || envToggle === "1" || envToggle === "yes";
+
+  if (!flag && !envEnabled) {
+    return null;
+  }
+
+  if (flag && flag.startsWith("--http=")) {
+    const p = parseInt(flag.slice("--http=".length), 10);
+    if (!Number.isNaN(p) && p > 0) return p;
+  }
+  const envPort = parseInt(envPortRaw ?? "", 10);
+  if (!Number.isNaN(envPort) && envPort > 0) return envPort;
+  return 3000;
 }
 
 /**
@@ -677,6 +706,16 @@ async function main() {
   skillState.skillMap = createSkillMap(skills);
   console.error(`Discovered ${skills.length} skill(s)`);
   warnLargeSkillCount(skills.length);
+
+  // HTTP transport: serve the core skill surface over stateless HTTP and return.
+  // The stdio path below (UI config/display tools, remote-source polling, file
+  // watching, dynamic refresh notifications) is intentionally skipped in HTTP
+  // mode — stateless HTTP cannot push notifications. Restart to pick up changes.
+  const httpPort = getHttpPort();
+  if (httpPort !== null) {
+    await startHttpServer(httpPort, skillState);
+    return;
+  }
 
   // Create the MCP server
   // In static mode, disable listChanged for tools/prompts (skills list is frozen)

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,7 +239,9 @@ export function getHttpPort(): number | null {
 
   if (flag && flag.startsWith("--http=")) {
     const p = parseInt(flag.slice("--http=".length), 10);
-    if (!Number.isNaN(p) && p > 0) return p;
+    // `>= 0` so `--http=0` binds an OS-assigned (ephemeral) port; the "ready"
+    // log line reports the actual port.
+    if (!Number.isNaN(p) && p >= 0) return p;
   }
   const envPort = parseInt(envPortRaw ?? "", 10);
   if (!Number.isNaN(envPort) && envPort > 0) return envPort;


### PR DESCRIPTION
## What

1. **Stateless HTTP transport** for skilljack (`--http[=port]` / `SKILLJACK_HTTP_PORT`). Serves the core skill surface at `POST /mcp` via per-request `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`. Default stdio path unchanged. (`src/http-transport.ts`, tests, docs.)
2. **Fix MCP-mode evals on agent-sdk 0.3.x.** Activation had collapsed to ~1/7 due to **two independent regressions**:
   - **A — stdio connect race**: the SDK connects stdio MCP servers asynchronously, so a stdio skilljack is `pending` at the model's first turn (upstream anthropics/claude-code#49753). → harness now runs skilljack over **HTTP** (`--http=0`), `connected` on turn 1.
   - **B — tool search / deferred tools**: MCP tool *descriptions* are deferred out of context, so the model never sees skilljack's `<available_skills>` catalog (which lives in the `load-skill` description) and won't activate. → harness sets **`ENABLE_TOOL_SEARCH=false`**.
   - Both needed together. Verified: code-style / template-generator / xlsx-openpyxl now PASS activation+following (were 0/3), across mcp / local / mcp+local.
3. **Product disclaimer** (README, CLAUDE.md, skilljack-docs, evals/README): the catalog-in-tool-description method only surfaces with tool search disabled; on modern Claude Code (tool search on) auto-activation is unreliable. Tracking the tool-search-on case in #78. The catalog is deliberately NOT duplicated into server `instructions`.

## Not done
Subagent delegation was explored and **dropped** — it's a band-aid that doesn't address regression B (branch name predates that decision).

## Verification
- `npm run build` + `npm test` → **232 green** (incl. 2 new HTTP transport tests).
- Manual: `node dist/index.js --http=3000 ./evals/skills` → `initialize` + `tools/list` over an MCP client; GET → 405.
- Evals: MCP-mode activation restored (see commit messages).

Refs: #78 (tool-search product issue), anthropics/claude-code#49753 (stdio race).

🤖 Generated with [Claude Code](https://claude.com/claude-code)