### PR TITLE
Single-channel skill catalog with instructions default + HTTP discovery-on-change

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,11 +21,13 @@ CI (`.github/workflows/ci.yml`) runs `npm ci`, `npm run build`, and `npm test` o
 - `WELL_KNOWN_MAX_UNPACKED_MB` - Archive uncompressed size cap (default 50)
 - `WELL_KNOWN_ALLOW_HTTP` - `1`/`true`/`yes` to permit `http://` origins (dev only)
 - `SKILLJACK_HTTP_PORT` / `SKILLJACK_HTTP` - Serve over stateless HTTP instead of stdio (port, default 3000)
+- `SKILLJACK_CATALOG` - Catalog delivery channel: `instructions` (default) | `tool-description` — exactly one, never both
 
 **CLI Options:**
 - Positional args: Skill directories, GitHub URLs, or well-known publisher URLs (e.g. `https://example.com/.well-known/agent-skills/`)
 - `--static`: Enable static mode (freeze skills at startup, no file watching)
 - `--http` / `--http=<port>`: Serve over stateless Streamable HTTP at `POST /mcp` instead of stdio (single token so it isn't parsed as a skill dir)
+- `--catalog=<instructions|tool-description>`: Which single channel carries the `<available_skills>` catalog (never both). `instructions` (default): server `instructions` — survives tool search, but frozen at startup on stdio since the SDK can't update instructions. `tool-description`: the `load-skill` tool description — dynamic via `tools/listChanged`, but deferred out of context by tool search. Env: `SKILLJACK_CATALOG`. See `getCatalogMode()` in index.ts / `CatalogMode` in skill-tool.ts.
 
 ## Project Structure
 
@@ -78,7 +80,7 @@ Packaging: `manifest.json` + `.mcpbignore` define the `.mcpb` bundle (MCP Bundle
 1. **Startup discovery**: Skills discovered from configured directories at startup (supports multiple)
 2. **File watching**: chokidar watches skill directories for SKILL.md changes
 3. **Dynamic refresh**: On file change → re-discover → update tool/prompts → send notifications
-4. **Tool description**: Skill metadata embedded in `load-skill` tool description, refreshable via `tools/listChanged`
+4. **Catalog delivery**: `<available_skills>` catalog in server `instructions` (default; sent at `initialize`, frozen until restart on stdio) or in the `load-skill` tool description (`--catalog=tool-description`; refreshable via `tools/listChanged`) — exactly one channel, never both
 5. **Prompts**: `/skill` prompt with auto-completion + per-skill prompts, refreshable via `prompts/listChanged`
 6. **Progressive disclosure**: Full SKILL.md loaded on demand via `load-skill` tool or prompts
 7. **MCP SDK patterns**: Uses `McpServer`, `ResourceTemplate`, `completable()`, Zod schemas
@@ -88,6 +90,7 @@ Packaging: `manifest.json` + `.mcpbignore` define the `.mcpb` bundle (MCP Bundle
 | Function | File | Purpose |
 |----------|------|---------|
 | `getStaticMode()` | index.ts | Check if static mode is enabled (CLI/env) |
+| `getCatalogMode()` | index.ts | Resolve the catalog channel (`--catalog=` / `SKILLJACK_CATALOG`, default `instructions`) |
 | `discoverSkillsFromDirs()` | index.ts | Scan directories for skills |
 | `refreshSkills()` | index.ts | Re-discover + update tool/prompts + notify clients |
 | `watchSkillDirectories()` | index.ts | Set up chokidar watchers (skipped in static mode) |
@@ -97,7 +100,9 @@ Packaging: `manifest.json` + `.mcpbignore` define the `.mcpb` bundle (MCP Bundle
 | `parseSkillResourceUri()` | skill-discovery.ts | Resolve a `skill://` URI back to a skill + file relpath |
 | `buildSkillIndex()` | skill-discovery.ts | Build the JSON document served at `skill://index.json` |
 | `generateInstructions()` | skill-discovery.ts | Create XML skill list |
-| `getToolDescription()` | skill-tool.ts | Usage text + skill list for tool desc |
+| `getToolDescription()` | skill-tool.ts | Tool desc: usage text (+ skill list in tool-description mode) |
+| `getServerInstructions()` | skill-tool.ts | Server `instructions` for a catalog mode (undefined in tool-description mode) |
+| `getCatalogInstructions()` | skill-tool.ts | Usage preamble + skill list for instructions mode |
 | `registerSkillPrompts()` | skill-prompts.ts | Register /skill + per-skill prompts |
 | `refreshPrompts()` | skill-prompts.ts | Update prompts when skills change |
 | `getPromptDescription()` | skill-prompts.ts | Usage text + skill list for prompt desc |
@@ -175,8 +180,8 @@ The resource layer follows [SEP-2640 (Skills Extension)](https://github.com/mode
 ## Conventions
 
 - ES modules (`.js` extensions in imports)
-- **Tool search / deferred tools limitation:** the skill catalog lives in the `load-skill` tool *description* (`getToolDescription`). Clients with tool search / deferred tool loading enabled (default on modern Claude Code) defer MCP tool descriptions out of context, so the model never sees the catalog and won't auto-activate — activation needs `ENABLE_TOOL_SEARCH=false`. Do NOT "fix" this by also stuffing the catalog into server `instructions`: instructions (static) and the tool description (dynamic) are deliberately independent, and `instructions` is becoming more optional in the spec. Making the dynamic catalog work under tool search is an open product problem (tracking issue).
-- Transports: stdio (default, full dynamic refresh + UI config/display tools) or stateless HTTP (`--http`, core skill surface only, per-request `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`, no push notifications). `main()` branches to `startHttpServer()` right after startup discovery.
+- **Tool search / deferred tools:** the skill catalog is delivered through exactly ONE channel, selected by `--catalog=` / `SKILLJACK_CATALOG` (never both simultaneously). In the default `instructions` mode the catalog arrives via the `initialize` handshake and **survives tool search** (verified by evals 2026-07-05: 3/3 previously-failing tasks pass with instructions + tool search on), at the cost of being frozen at startup on stdio (the SDK cannot update instructions after construction). On HTTP the catalog stays fresh for *new* connections: file watchers/polling update skillState and instructions are regenerated per request — but MCP only delivers instructions at `initialize`, so already-connected clients see catalog changes only after reconnecting. In `tool-description` mode the catalog is dynamic via `tools/listChanged`, but clients with tool search / deferred tool loading enabled (default on modern Claude Code) defer MCP tool descriptions out of context, so the model never sees it and won't auto-activate — that mode needs `ENABLE_TOOL_SEARCH=false`. Issue #78 tracks the remaining questions (dynamic refresh under instructions mode, caching/cost).
+- Transports: stdio (default, full dynamic refresh + UI config/display tools) or stateless HTTP (`--http`, core skill surface only, per-request `StreamableHTTPServerTransport({ sessionIdGenerator: undefined })`, no push notifications). `main()` branches to `startHttpServer()` right after startup discovery, first wiring the same file watchers + remote polling as stdio to a state-only refresh (`refreshSkillState`) — requests read skillState fresh, clients just aren't notified.
 - Errors logged to stderr (stdout is MCP protocol)
 - Security: path traversal checks via `isPathWithinBase()`
 - File size limit: 1MB default (`MAX_FILE_SIZE_MB` env var to configure)

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 An MCP server that jacks [Agent Skills](https://agentskills.io) directly into your LLM's brain.
 
-> ⚠️ **Heads up — tool search / deferred tools.** Skilljack surfaces its skill catalog through the `load-skill` **tool description**. Clients with **tool search / deferred tool loading** on (the default on modern Claude Code) don't load MCP tool descriptions into context up front, so the model won't reliably auto-activate skilljack skills. Set `ENABLE_TOOL_SEARCH=false` to use automatic activation today. Working with tool search enabled is an open item.
+> **Tool search / deferred tools.** By default, skilljack delivers its skill catalog via MCP **server instructions**, which arrive in the `initialize` handshake and are visible to the model even when **tool search / deferred tool loading** is enabled (the default on modern Claude Code) — so automatic skill activation works out of the box. The alternative `--catalog=tool-description` mode delivers the catalog through the `load-skill` tool description instead (dynamic via `tools/listChanged`), but tool-search clients defer tool descriptions out of context, so that mode needs `ENABLE_TOOL_SEARCH=false` to auto-activate.
 
 ## Installation
 
@@ -54,9 +54,16 @@ skilljack-mcp --static /path/to/skills
 # Serve over HTTP instead of stdio (stateless Streamable HTTP on POST /mcp)
 skilljack-mcp --http=3000 /path/to/skills
 # or: SKILLJACK_HTTP_PORT=3000 skilljack-mcp /path/to/skills
+
+# Deliver the skill catalog via the load-skill tool description instead of
+# server instructions (the default)
+skilljack-mcp --catalog=tool-description /path/to/skills
+# or: SKILLJACK_CATALOG=tool-description skilljack-mcp /path/to/skills
 ```
 
-**Transports:** stdio (default) or stateless HTTP (`--http[=port]`, default `3000`, or `SKILLJACK_HTTP_PORT`). HTTP serves the core skill surface (`load-skill`, `skill-resource`, `skill://` resources, `/skill` prompts) at `POST /mcp`. Because it is stateless, it does not push `listChanged`/`resources/updated` notifications — skills are read at startup; restart to pick up changes. Use stdio for the dynamic-refresh and MCP-Apps UI features.
+**Transports:** stdio (default) or stateless HTTP (`--http[=port]`, default `3000`, or `SKILLJACK_HTTP_PORT`). HTTP serves the core skill surface (`load-skill`, `skill-resource`, `skill://` resources, `/skill` prompts) at `POST /mcp`. Discovery-on-change works the same as stdio — file watchers and remote-source polling keep the skill state fresh, and every request (including each new client's `initialize`) reads it. Because the transport is stateless it does not *push* `listChanged`/`resources/updated` notifications: already-connected clients see changes on their next request or reconnect. The MCP-Apps configuration UI is stdio-only.
+
+**Catalog channel:** `--catalog=<instructions|tool-description>` (or `SKILLJACK_CATALOG`) picks which single channel delivers the `<available_skills>` catalog — never both. `instructions` (default): server `instructions`, sent in the `initialize` handshake so it survives tool-search deferral; on stdio it is frozen at startup — skill changes need a restart (over HTTP, newly connecting clients always get a current catalog). `tool-description`: the `load-skill` tool description, dynamic via `tools/listChanged` but invisible to clients that defer MCP tool descriptions (e.g. Claude Code tool search).
 
 ## Configuration and Skills Display UI
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -21,9 +21,23 @@ npm run build
 On agent-sdk 0.3.x, MCP-mode evals only measure skill activation meaningfully after working around **two independent regressions** (the harness does this automatically — see `lib/options-builder.ts`):
 
 1. **stdio connect race** — the SDK connects stdio MCP servers *asynchronously*, so a stdio skilljack is still `pending` at the model's first turn and its tools are absent (upstream [anthropics/claude-code#49753](https://github.com/anthropics/claude-code/issues/49753)). The harness runs skilljack over **HTTP** (`--http=0`, ephemeral port) instead of stdio so it is `connected` on turn 1.
-2. **tool search / deferred tools** — MCP tool *descriptions* are deferred out of context, so the model never sees skilljack's `<available_skills>` catalog (which lives in the `load-skill` tool description) and won't activate. The harness sets **`ENABLE_TOOL_SEARCH=false`** so all tool definitions load into context every turn.
+2. **tool search / deferred tools** — MCP tool *descriptions* are deferred out of context, so in `--catalog=tool-description` mode the model never sees skilljack's `<available_skills>` catalog and won't activate. The default `instructions` catalog mode is immune (the catalog arrives via the `initialize` handshake), but the harness still sets **`ENABLE_TOOL_SEARCH=false`** by default for uniform tool visibility across modes; override with `--tool-search=on`.
 
-**Product caveat:** #2 means skilljack's catalog-in-the-tool-description approach only surfaces to the model when tool search is disabled. On a default modern Claude Code (tool search on), auto-activation of MCP-delivered skills is unreliable — see the disclaimer in the main docs and the tracking issue.
+### Catalog-channel knobs (`--catalog` + `--tool-search`)
+
+Skilljack delivers the skill catalog through exactly one channel: server `instructions` (default) or the `load-skill` tool description — see `--catalog=` in the main README. Server `instructions` arrive in the `initialize` handshake rather than a (deferrable) tool description, which is why they survive tool search ON. The harness exposes both knobs:
+
+```bash
+# Default catalog (instructions), tool search ENABLED — passes
+npm run eval -- --task=code-style --mode=mcp --tool-search=on
+
+# Catalog via tool description, tool search ENABLED (fails — description is deferred)
+npm run eval -- --task=code-style --mode=mcp --catalog=tool-description --tool-search=on
+```
+
+`--catalog` is passed to the spawned skilljack server (MCP modes only); `--tool-search` sets `ENABLE_TOOL_SEARCH` explicitly (both on and off) on the Agent SDK client env. Both settings are recorded in the result summary JSON.
+
+**Result (2026-07-05, agent-sdk 0.3.201, claude-sonnet-4-6):** the instructions channel survives tool search — this is why it became the default. With the default catalog (no `--catalog` flag) and `--tool-search=on`, all 3 tasks pass (code-style, template-generator, xlsx-openpyxl — all of which fail in tool-description mode with tool search on); the tool-description + tool-search-on control failed as expected; tool-description + tool-search-off also passes. Reproduced across two batches, including one exercising the HTTP discovery-on-change path.
 
 ## Running Evals
 

--- a/evals/eval.ts
+++ b/evals/eval.ts
@@ -9,12 +9,14 @@ import {
   SessionLogger
 } from "./lib/metrics.js";
 import { analyzeSession, printEvalResult, EvalConfig } from "./lib/eval-checker.js";
-import { buildOptions, cleanupLocalSkills, cleanupEvalServers, EvalMode } from "./lib/options-builder.js";
+import { buildOptions, cleanupLocalSkills, cleanupEvalServers, EvalMode, CatalogMode, ToolSearchSetting } from "./lib/options-builder.js";
 
 interface CLIArgs {
   task: string;
   mode: EvalMode;
   model?: string;
+  catalog?: CatalogMode;
+  toolSearch: ToolSearchSetting;
 }
 
 interface TaskConfig {
@@ -28,6 +30,8 @@ function parseArgs(): CLIArgs {
   let task = "greeting"; // default
   let mode: EvalMode = "mcp"; // default
   let model: string | undefined;
+  let catalog: CatalogMode | undefined;
+  let toolSearch: ToolSearchSetting = "off"; // default = pre-existing behavior
 
   for (const arg of args) {
     if (arg.startsWith("--task=")) {
@@ -42,6 +46,22 @@ function parseArgs(): CLIArgs {
       }
     } else if (arg.startsWith("--model=")) {
       model = arg.split("=")[1];
+    } else if (arg.startsWith("--catalog=")) {
+      const catalogArg = arg.split("=")[1];
+      if (catalogArg === "tool-description" || catalogArg === "instructions") {
+        catalog = catalogArg;
+      } else {
+        console.error(`Invalid catalog mode: ${catalogArg}. Use 'tool-description' or 'instructions'.`);
+        process.exit(1);
+      }
+    } else if (arg.startsWith("--tool-search=")) {
+      const tsArg = arg.split("=")[1];
+      if (tsArg === "on" || tsArg === "off") {
+        toolSearch = tsArg;
+      } else {
+        console.error(`Invalid tool-search setting: ${tsArg}. Use 'on' or 'off'.`);
+        process.exit(1);
+      }
     } else if (arg === "--help" || arg === "-h") {
       console.log(`
 Usage: tsx evals/eval.ts [options]
@@ -55,6 +75,13 @@ Options:
                        cli-local: Use Claude Code CLI directly (non-interactive)
                        mcp+local: Both MCP server AND local skills enabled
   --model=<model-id>   Specify the Claude model to use
+  --catalog=<tool-description|instructions>
+                       Skilljack catalog delivery channel (MCP modes only;
+                       passed to the server as --catalog. Default: server
+                       default, i.e. instructions)
+  --tool-search=<on|off>  Agent SDK tool search / deferred tool loading
+                       (default: off. The tool-description catalog requires
+                       off; --catalog=instructions is the experiment for on)
   --help, -h           Show this help message
 
 Examples:
@@ -64,12 +91,13 @@ Examples:
   tsx evals/eval.ts --mode=mcp+local         # Run with both MCP and local skills
   tsx evals/eval.ts --task=greeting --mode=mcp
   tsx evals/eval.ts --task=code-style --mode=cli-local
+  tsx evals/eval.ts --task=code-style --mode=mcp --catalog=instructions --tool-search=on
 `);
       process.exit(0);
     }
   }
 
-  return { task, mode, model };
+  return { task, mode, model, catalog, toolSearch };
 }
 
 async function loadTask(taskName: string): Promise<TaskConfig> {
@@ -200,7 +228,7 @@ function parseCLIOutput(output: string): CLIResult {
 }
 
 async function main() {
-  const { task: taskName, mode, model } = parseArgs();
+  const { task: taskName, mode, model, catalog, toolSearch } = parseArgs();
   const startTime = Date.now();
 
   console.log("=== Skill Eval ===\n");
@@ -214,10 +242,14 @@ async function main() {
     mode,
     systemPrompt: taskConfig.systemPrompt,
     model,
-    skillsDir: './evals/skills'
+    skillsDir: './evals/skills',
+    catalog,
+    toolSearch
   });
 
   console.log(`\nMode: ${mode}`);
+  console.log(`Catalog: ${catalog ?? "(server default: instructions)"}`);
+  console.log(`Tool search: ${toolSearch}`);
   if (mode === "mcp") {
     console.log(`MCP Servers: ${Object.keys(options.mcpServers || {}).join(', ')}`);
   } else if (mode === "mcp+local") {
@@ -326,7 +358,7 @@ async function main() {
     console.log(`Human-readable log: ${logPath.replace('.json', '.md')}`);
 
     // Save result summary
-    await saveResultSummary(taskName, evalResult, logger.getSessionId(), taskConfig.evalConfig, mode);
+    await saveResultSummary(taskName, evalResult, logger.getSessionId(), taskConfig.evalConfig, mode, catalog, toolSearch);
 
     // Cleanup local skills if in local, cli-local, or mcp+local mode
     if (mode === "local" || mode === "cli-local" || mode === "mcp+local") {
@@ -347,7 +379,9 @@ async function saveResultSummary(
   evalResult: ReturnType<typeof analyzeSession>,
   sessionId: string,
   evalConfig: EvalConfig,
-  mode: EvalMode
+  mode: EvalMode,
+  catalog: CatalogMode | undefined,
+  toolSearch: ToolSearchSetting
 ): Promise<void> {
   const resultsDir = './evals/results';
   await fs.mkdir(resultsDir, { recursive: true });
@@ -361,6 +395,8 @@ async function saveResultSummary(
     timestamp: new Date().toISOString(),
     task: taskName,
     mode,
+    catalog: catalog ?? "instructions",
+    toolSearch,
     sessionId,
     passed,
     results: evalResult

--- a/evals/lib/options-builder.ts
+++ b/evals/lib/options-builder.ts
@@ -6,6 +6,15 @@ import { spawn, ChildProcess } from "child_process";
 export type EvalMode = "mcp" | "local" | "cli-local" | "mcp+local";
 
 /**
+ * Which channel the skilljack server under test uses for the skill catalog
+ * (passed through as `--catalog=<mode>`; see CatalogMode in src/skill-tool.ts).
+ */
+export type CatalogMode = "tool-description" | "instructions";
+
+/** Whether the Agent SDK client runs with tool search (deferred tool loading). */
+export type ToolSearchSetting = "on" | "off";
+
+/**
  * skilljack HTTP servers spawned for MCP-mode evals. Tracked so eval.ts can
  * tear them down after each run via cleanupEvalServers().
  */
@@ -19,7 +28,7 @@ const spawnedHttpServers: ChildProcess[] = [];
  * model's first turn — the agent-sdk 0.3.x stdio connect race leaves a
  * stdio server `pending` and its tools absent turn 1. See evals/README.md.
  */
-async function startSkilljackHttp(skillsDir: string): Promise<string> {
+async function startSkilljackHttp(skillsDir: string, extraArgs: string[] = []): Promise<string> {
   const serverPath = path.resolve("./dist/index.js");
   try {
     await fs.access(serverPath);
@@ -27,7 +36,7 @@ async function startSkilljackHttp(skillsDir: string): Promise<string> {
     throw new Error(`Skilljack MCP server not found at ${serverPath}. Run 'npm run build' first.`);
   }
   const absoluteSkillsDir = path.resolve(skillsDir);
-  const proc = spawn("node", [serverPath, "--http=0", absoluteSkillsDir], {
+  const proc = spawn("node", [serverPath, "--http=0", ...extraArgs, absoluteSkillsDir], {
     stdio: ["ignore", "ignore", "pipe"],
   });
   spawnedHttpServers.push(proc);
@@ -68,15 +77,23 @@ export function cleanupEvalServers(): void {
  * into context every turn. With tool search ON (default), MCP tool descriptions
  * are DEFERRED out of context, so the model never sees the skill catalog and
  * won't activate. Skilljack's catalog-in-tool-description method requires this
- * to be off. See evals/README.md.
+ * to be off; the catalog-in-instructions method (--catalog=instructions) is the
+ * experiment for surviving tool search ON. See evals/README.md.
+ *
+ * Always set explicitly (both "true" and "false") so a stray value in the
+ * parent shell environment can't skew runs.
  */
-const TOOL_SEARCH_OFF_ENV = { ENABLE_TOOL_SEARCH: "false" as const };
+function toolSearchEnv(toolSearch: ToolSearchSetting): { ENABLE_TOOL_SEARCH: string } {
+  return { ENABLE_TOOL_SEARCH: toolSearch === "on" ? "true" : "false" };
+}
 
 export interface BuildOptionsConfig {
   mode: EvalMode;
   systemPrompt?: string;  // Optional - uses Claude Code default if not provided
   model?: string;
   skillsDir: string;  // Path to test skills directory
+  catalog?: CatalogMode;  // Skilljack --catalog mode (MCP modes; server default "instructions" if unset)
+  toolSearch?: ToolSearchSetting;  // Agent SDK tool search (default "off" = pre-existing behavior)
 }
 
 /**
@@ -165,7 +182,8 @@ async function copyDir(src: string, dest: string): Promise<void> {
  * Build query options for skill eval
  */
 export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
-  const { mode, systemPrompt, model, skillsDir } = config;
+  const { mode, systemPrompt, model, skillsDir, catalog, toolSearch = "off" } = config;
+  const skilljackArgs = catalog ? [`--catalog=${catalog}`] : [];
 
   // Default to Sonnet 4.6
   const modelId = model || "claude-sonnet-4-6";
@@ -227,7 +245,7 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
       model: modelId,
       // Uniform tool visibility across modes (the native Skill tool can also be
       // deferred under tool search); keeps cross-mode comparisons apples-to-apples.
-      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
+      env: { ...process.env, ...toolSearchEnv(toolSearch) }
     };
   } else if (mode === "mcp+local") {
     // Combined mode: both MCP server (over HTTP) AND local skills enabled.
@@ -235,7 +253,7 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
     await setupLocalSkills(skillsDir);
     await ensureSettingsJson();
 
-    const url = await startSkilljackHttp(skillsDir);
+    const url = await startSkilljackHttp(skillsDir, skilljackArgs);
 
     options = {
       cwd: process.cwd(),
@@ -248,12 +266,14 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
       allowedTools: ["Bash", "Read", "Write", "Skill", "mcp__skilljack"],
       permissionMode: "default" as const,
       model: modelId,
-      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
+      env: { ...process.env, ...toolSearchEnv(toolSearch) }
     };
   } else {
     // MCP mode: skilljack over HTTP (avoids the stdio connect race, regression A)
-    // + tool search off (surfaces the tool-description catalog, regression B).
-    const url = await startSkilljackHttp(skillsDir);
+    // + tool search off by default (surfaces the tool-description catalog,
+    // regression B). --tool-search=on + --catalog=instructions is the
+    // instructions-channel experiment.
+    const url = await startSkilljackHttp(skillsDir, skilljackArgs);
 
     options = {
       cwd: process.cwd(),
@@ -264,7 +284,7 @@ export async function buildOptions(config: BuildOptionsConfig): Promise<any> {
       allowedTools: ["mcp__skilljack"],
       permissionMode: "default" as const,
       model: modelId,
-      env: { ...process.env, ...TOOL_SEARCH_OFF_ENV }
+      env: { ...process.env, ...toolSearchEnv(toolSearch) }
     };
   }
 

--- a/skills/skilljack-docs/SKILL.md
+++ b/skills/skilljack-docs/SKILL.md
@@ -9,7 +9,7 @@ An MCP server that jacks [Agent Skills](https://agentskills.io) directly into yo
 
 > **Recommended:** For best results, use an MCP client that supports `tools/listChanged` notifications (e.g., Claude Code). This enables dynamic skill discovery - when skills are added or modified, the client automatically refreshes its understanding of available skills. Alternatively, use `--static` mode for predictable behavior with a fixed skill set.
 
-> ⚠️ **Tool search / deferred tools limitation.** Skilljack delivers its skill catalog inside the `load-skill` **tool description**. Clients with **tool search / deferred tool loading** enabled (the default on modern Claude Code, ~2.1.x) do **not** load MCP tool descriptions into the model's context up front — they are discovered on demand — so the model does not see the `<available_skills>` catalog and will **not reliably auto-activate** skilljack skills. To use skilljack's automatic activation today, **disable tool search** (e.g. `ENABLE_TOOL_SEARCH=false`). Making skilljack work with tool search enabled is an open item ([tracking issue](https://github.com/olaservo/skilljack-mcp/issues)).
+> **Tool search / deferred tools.** By default, skilljack delivers its skill catalog via MCP **server instructions**, which arrive in the `initialize` handshake and reach the model even when **tool search / deferred tool loading** is enabled (the default on modern Claude Code, ~2.1.x) — automatic skill activation works out of the box. The alternative `--catalog=tool-description` mode delivers the catalog inside the `load-skill` tool description (dynamically refreshable via `tools/listChanged`), but tool-search clients defer MCP tool descriptions out of context, so that mode requires disabling tool search (e.g. `ENABLE_TOOL_SEARCH=false`) for auto-activation. See [Catalog Delivery](#catalog-delivery).
 
 ## Features
 
@@ -27,7 +27,8 @@ An MCP server that jacks [Agent Skills](https://agentskills.io) directly into yo
 This server demonstrates a way to approach integrating skills using existing MCP primitives.
 
 MCP already has the building blocks:
-- **Tools** for on-demand skill loading (the `load-skill` tool with dynamically updated descriptions)
+- **Tools** for on-demand skill loading (the `load-skill` tool)
+- **Server instructions** for surfacing the skill catalog at `initialize` (the default catalog channel)
 - **Resources** for explicit skill access (`skill://` URIs)
 - **Notifications** for real-time updates (`tools/listChanged`, `resources/updated`)
 - **Prompts** for explicitly invoking skills by name (`/my-server-skill`)
@@ -97,6 +98,21 @@ Use static mode when you need predictable behavior or have a fixed set of skills
 skilljack-mcp "C:/Users/you/skills"
 ```
 
+### Catalog Delivery
+
+The `<available_skills>` catalog is delivered through exactly **one** channel, selected with `--catalog=<mode>` or `SKILLJACK_CATALOG` — never both:
+
+```bash
+# Default: catalog in server instructions (survives tool search)
+skilljack-mcp /path/to/skills
+
+# Alternative: catalog in the load-skill tool description
+skilljack-mcp --catalog=tool-description /path/to/skills
+```
+
+- **`instructions`** (default) — the catalog (plus `load-skill` usage guidance) is sent as MCP server `instructions` in the `initialize` handshake. It is visible to the model even under tool search / deferred tool loading. Trade-off: on stdio, the MCP SDK sets instructions once at construction, so the catalog is **frozen until restart** — live skill add/remove won't reach connected clients. (Over HTTP, instructions are regenerated per request from the watched skill state, so *newly connecting* clients always get a current catalog; already-connected clients receive instructions only at `initialize` and see changes after reconnecting.)
+- **`tool-description`** — the catalog lives in the `load-skill` tool description and refreshes live via `tools/listChanged` when skills change. Trade-off: clients with tool search enabled defer MCP tool descriptions out of context, so the model never sees the catalog; requires `ENABLE_TOOL_SEARCH=false` for auto-activation.
+
 ### HTTP Transport
 
 By default skilljack communicates over **stdio**. To serve over **stateless Streamable HTTP** instead, use `--http` (or `SKILLJACK_HTTP_PORT`):
@@ -105,7 +121,7 @@ By default skilljack communicates over **stdio**. To serve over **stateless Stre
 skilljack-mcp --http=3000 /path/to/skills
 ```
 
-Clients connect at `POST /mcp`. HTTP mode serves the core skill surface — `load-skill`, `skill-resource`, `skill://` resources, and `/skill` prompts. Because it is stateless (no session, no server→client stream), it does **not** send `listChanged` / `resources/updated` notifications, and the UI config/display tools are stdio-only. Skills are read at startup; restart to pick up on-disk changes. Use stdio when you need dynamic refresh or the configuration UI.
+Clients connect at `POST /mcp`. HTTP mode serves the core skill surface — `load-skill`, `skill-resource`, `skill://` resources, and `/skill` prompts. Discovery-on-change works the same as stdio: file watchers and remote-source polling keep the skill state fresh, and every request reads it — so newly connecting clients get a current catalog, and `load-skill`/`tools/list` reflect changes immediately. Because the transport is stateless (no session, no server→client stream), it does **not** *push* `listChanged` / `resources/updated` notifications — already-connected clients see changes on their next request (for the instructions catalog, on their next reconnect). The UI config/display tools are stdio-only.
 
 ## Configuration UI
 
@@ -143,8 +159,8 @@ Skills from GitHub repositories show the org/repo name (e.g., `modelcontextproto
 The server implements the [Agent Skills](https://agentskills.io) progressive disclosure pattern with dynamic updates:
 
 1. **At startup**: Discovers skills from configured directories and starts file watchers
-2. **On connection**: `load-skill` tool description includes available skills metadata
-3. **On file change**: Re-discovers skills, updates tool description, sends `tools/listChanged`
+2. **On connection**: the skill catalog is delivered via server instructions (default) or the `load-skill` tool description (`--catalog=tool-description`)
+3. **On file change**: Re-discovers skills, updates the tool description and prompts, sends `tools/listChanged` (in tool-description mode this refreshes the catalog; in instructions mode the catalog is frozen until restart on stdio)
 4. **On tool call**: Agent calls `load-skill` tool to load full SKILL.md content
 5. **As needed**: Agent calls `skill-resource` to load additional files
 
@@ -155,10 +171,11 @@ The server implements the [Agent Skills](https://agentskills.io) progressive dis
 │   • Starts watching for SKILL.md changes                 │
 │   ↓                                                      │
 │ MCP Client connects                                      │
-│   • load-skill tool description includes available skills│
+│   • Skill catalog delivered via server instructions      │
+│     (default) or load-skill tool description             │
 │   • Prompts registered for each skill                    │
 │   ↓                                                      │
-│ LLM sees skill metadata in tool description              │
+│ LLM sees skill metadata in the catalog                   │
 │   ↓                                                      │
 │ SKILL.md added/modified/removed                          │
 │   • Server re-discovers skills                           │
@@ -182,7 +199,7 @@ The server implements the [Agent Skills](https://agentskills.io) progressive dis
 
 This server exposes skills via **tools**, **resources**, and **prompts**:
 
-- **Tools** (`load-skill`, `skill-resource`) - For your agent to use autonomously. The LLM sees available skills in the tool description and calls them as needed.
+- **Tools** (`load-skill`, `skill-resource`) - For your agent to use autonomously. The LLM sees available skills in the skill catalog (server instructions by default, or the `load-skill` tool description) and calls them as needed.
 - **Prompts** (`/skill`, `/skill-name`) - For explicit user invocation. Use `/skill` with auto-completion or select a skill directly by name.
 - **Resources** (`skill://` URIs) - For manual selection in apps that support it (e.g., Claude Desktop's resource picker). Useful when you want to explicitly attach a skill to the conversation.
 
@@ -200,13 +217,13 @@ This server implements the [Agent Skills progressive disclosure pattern](https:/
 
 ### How it works
 
-1. **Discovery** - Server loads metadata from all skills into the `load-skill` tool description
+1. **Discovery** - Server loads metadata from all skills into the skill catalog (server instructions by default, or the `load-skill` tool description)
 2. **Activation** - When a skill is loaded (via tool, prompt, or resource), only the SKILL.md content is returned
 3. **Execution** - SKILL.md references additional files; agent fetches them with `skill-resource` as needed
 
 ### Why SKILL.md documents its own resources
 
-The `load-skill` tool description and the loaded SKILL.md body don't enumerate every file in a skill directory. Instead, skill authors document available resources directly in their SKILL.md (e.g., "Copy the template from `templates/server.ts`"). This design choice follows the spec because:
+The skill catalog and the loaded SKILL.md body don't enumerate every file in a skill directory. Instead, skill authors document available resources directly in their SKILL.md (e.g., "Copy the template from `templates/server.ts`"). This design choice follows the spec because:
 
 - **Skill authors know best** - They decide which files are relevant and when to use them
 - **Context efficiency** - Loading everything upfront wastes tokens on files the agent may not need
@@ -362,14 +379,14 @@ Not protected against:
 The server watches skill directories for changes. When SKILL.md files are added, modified, or removed:
 
 1. Skills are re-discovered from all configured directories
-2. The `load-skill` tool's description is updated with current skill names and metadata
+2. The `load-skill` tool's description is updated with current skill names and metadata (in `--catalog=tool-description` mode; in the default instructions mode the catalog itself is frozen until restart on stdio)
 3. Per-skill prompts are added, removed, or updated accordingly
 4. `tools/listChanged` and `prompts/listChanged` notifications are sent to connected clients
 5. Clients that support these notifications will refresh tool and prompt definitions
 
 ## Skill Metadata Format
 
-The `load-skill` tool description includes metadata for all available skills in XML format:
+The skill catalog (server instructions by default, or the `load-skill` tool description in `--catalog=tool-description` mode) includes metadata for all available skills in XML format:
 
 ```markdown
 # Skills
@@ -385,7 +402,7 @@ When a user's task matches a skill description below: 1) activate it, 2) follow 
 </available_skills>
 ```
 
-This metadata is dynamically updated when skills change - clients supporting `tools/listChanged` will automatically refresh.
+In tool-description mode this metadata is dynamically updated when skills change — clients supporting `tools/listChanged` will automatically refresh. In the default instructions mode it is generated at startup (stdio) or per request (HTTP).
 
 ## Skill Discovery
 
@@ -400,7 +417,7 @@ Each skill subdirectory must contain a `SKILL.md` file with YAML frontmatter inc
 
 Control which skills appear in tools vs prompts using optional frontmatter fields:
 
-| Frontmatter | In Tool Description | In Prompts Menu | Use Case |
+| Frontmatter | In Skill Catalog | In Prompts Menu | Use Case |
 |-------------|---------------------|-----------------|----------|
 | (default) | Yes | Yes | Normal skills |
 | `disable-model-invocation: true` | No | Yes | User-triggered workflows (deploy, commit) |

--- a/src/http-transport.test.ts
+++ b/src/http-transport.test.ts
@@ -60,4 +60,101 @@ describe("stateless HTTP transport", () => {
       await new Promise<void>((resolve) => server.close(() => resolve()));
     }
   });
+
+  it("serves refreshed skillState to new connections (discovery-on-change)", async () => {
+    const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+    const state = createTestSkillState([
+      createTestSkill({
+        name: "first-skill",
+        baseName: "first-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      }),
+    ]);
+    const server = await startHttpServer(0, state);
+    const url = new URL(`http://127.0.0.1:${portOf(server)}/mcp`);
+
+    async function instructionsSeenByNewClient(): Promise<string | undefined> {
+      const client = new Client({ name: "test-client", version: "0.0.1" });
+      const transport = new StreamableHTTPClientTransport(url);
+      try {
+        await client.connect(transport);
+        return client.getInstructions();
+      } finally {
+        await client.close().catch(() => {});
+        await transport.close().catch(() => {});
+      }
+    }
+
+    try {
+      expect(await instructionsSeenByNewClient()).toContain("<name>first-skill</name>");
+
+      // Simulate what refreshSkillState() does on a file change: swap the map.
+      const added = createTestSkill({
+        name: "second-skill",
+        baseName: "second-skill",
+        path: skillPath,
+        source: BUNDLED_SKILL_SOURCE,
+      });
+      state.skillMap = new Map([
+        ...state.skillMap,
+        [added.name, added],
+      ]);
+
+      const instructions = await instructionsSeenByNewClient();
+      expect(instructions).toContain("<name>first-skill</name>");
+      expect(instructions).toContain("<name>second-skill</name>");
+    } finally {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  describe("catalog modes", () => {
+    function makeState() {
+      const skillPath = path.join(FIXTURES_DIR, "valid-skill", "SKILL.md");
+      return createTestSkillState([
+        createTestSkill({
+          name: "test-skill",
+          baseName: "test-skill",
+          path: skillPath,
+          source: BUNDLED_SKILL_SOURCE,
+        }),
+      ]);
+    }
+
+    async function connectAndInspect(catalogMode?: "tool-description" | "instructions") {
+      const server = await startHttpServer(0, makeState(), catalogMode);
+      const client = new Client({ name: "test-client", version: "0.0.1" });
+      const transport = new StreamableHTTPClientTransport(
+        new URL(`http://127.0.0.1:${portOf(server)}/mcp`)
+      );
+      try {
+        await client.connect(transport);
+        const instructions = client.getInstructions();
+        const tools = await client.listTools();
+        const loadSkillDesc = tools.tools.find((t) => t.name === "load-skill")?.description ?? "";
+        return { instructions, loadSkillDesc };
+      } finally {
+        await client.close().catch(() => {});
+        await transport.close().catch(() => {});
+        await new Promise<void>((resolve) => server.close(() => resolve()));
+      }
+    }
+
+    it("tool-description: no instructions, catalog in tool description", async () => {
+      const { instructions, loadSkillDesc } = await connectAndInspect("tool-description");
+      expect(instructions).toBeUndefined();
+      expect(loadSkillDesc).toContain("<name>test-skill</name>");
+    });
+
+    it("instructions (default): catalog + load-skill usage in instructions, usage-only tool description", async () => {
+      for (const mode of ["instructions", undefined] as const) {
+        const { instructions, loadSkillDesc } = await connectAndInspect(mode);
+        expect(instructions).toContain("<name>test-skill</name>");
+        expect(instructions).toContain("`load-skill`");
+        expect(loadSkillDesc).toContain("Load a skill");
+        expect(loadSkillDesc).not.toContain("<available_skills>");
+      }
+    });
+  });
 });

--- a/src/http-transport.ts
+++ b/src/http-transport.ts
@@ -8,28 +8,37 @@
  * between requests.
  *
  * Limitation: stateless mode has no server->client stream, so listChanged /
- * resources/updated notifications are not delivered. Skills are read from the
- * skillState captured at startup; restart to pick up on-disk changes. The
- * default stdio transport keeps full dynamic-refresh behavior.
+ * resources/updated notifications are not delivered. Discovery-on-change still
+ * works: main() runs the same file watchers / remote polling as stdio and swaps
+ * skillState, and every request reads that state fresh — but clients are not
+ * *told* about changes; they see them on their next request (or, for the
+ * instructions catalog, their next initialize/reconnect).
  */
 
 import * as http from "node:http";
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
-import { registerSkillTool, SkillState } from "./skill-tool.js";
+import { registerSkillTool, getServerInstructions, SkillState, CatalogMode } from "./skill-tool.js";
 import { registerSkillResources } from "./skill-resources.js";
 import { registerSkillPrompts } from "./skill-prompts.js";
-import { generateInstructions, getModelInvocableSkills } from "./skill-discovery.js";
 
 /**
  * Build a fresh McpServer exposing the core skill surface for one request.
  *
  * listChanged/subscribe are advertised as false: stateless HTTP cannot push
  * notifications, so promising them would be dishonest.
+ *
+ * catalogMode picks which single channel carries the skill catalog (tool
+ * description or server instructions — see CatalogMode). Instructions are
+ * regenerated from the current skillState on every request (unlike stdio,
+ * where the SDK freezes them at construction), so newly connecting clients
+ * see skill changes picked up by the watchers in main().
  */
-export function buildCoreServer(skillState: SkillState): McpServer {
-  const skills = Array.from(skillState.skillMap.values());
-  const instructions = generateInstructions(getModelInvocableSkills(skills));
+export function buildCoreServer(
+  skillState: SkillState,
+  catalogMode: CatalogMode = "instructions"
+): McpServer {
+  const instructions = getServerInstructions(skillState, catalogMode);
 
   const server = new McpServer(
     { name: "skilljack-mcp", version: "1.0.0" },
@@ -43,11 +52,11 @@ export function buildCoreServer(skillState: SkillState): McpServer {
           "io.modelcontextprotocol/skills": {},
         },
       },
-      instructions,
+      ...(instructions !== undefined && { instructions }),
     }
   );
 
-  registerSkillTool(server, skillState);
+  registerSkillTool(server, skillState, catalogMode);
   registerSkillResources(server, skillState);
   registerSkillPrompts(server, skillState);
 
@@ -61,7 +70,11 @@ const JSONRPC_ERROR = (code: number, message: string) =>
  * Start a stateless Streamable HTTP MCP server on the given port.
  * Resolves with the listening http.Server once it is accepting connections.
  */
-export async function startHttpServer(port: number, skillState: SkillState): Promise<http.Server> {
+export async function startHttpServer(
+  port: number,
+  skillState: SkillState,
+  catalogMode: CatalogMode = "instructions"
+): Promise<http.Server> {
   const httpServer = http.createServer(async (req, res) => {
     const url = req.url ?? "";
     if (req.method !== "POST" || !(url === "/mcp" || url.startsWith("/mcp?"))) {
@@ -71,7 +84,7 @@ export async function startHttpServer(port: number, skillState: SkillState): Pro
     }
 
     // Fresh server + transport per request (stateless).
-    const server = buildCoreServer(skillState);
+    const server = buildCoreServer(skillState, catalogMode);
     const transport = new StreamableHTTPServerTransport({ sessionIdGenerator: undefined });
     res.on("close", () => {
       transport.close();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock("./skill-config.js", () => ({
 }));
 
 // Import after mocking
-import { classifyPaths, getStaticMode } from "./index.js";
+import { classifyPaths, getStaticMode, getCatalogMode } from "./index.js";
 import { getStaticModeFromConfig } from "./skill-config.js";
 
 describe("classifyPaths", () => {
@@ -102,5 +102,62 @@ describe("getStaticMode", () => {
     process.argv = ["node", "script.js"];
     process.env.SKILLJACK_STATIC = "TRUE";
     expect(getStaticMode()).toBe(true);
+  });
+});
+
+describe("getCatalogMode", () => {
+  const originalArgv = process.argv;
+  const originalEnv = process.env.SKILLJACK_CATALOG;
+
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    if (originalEnv === undefined) {
+      delete process.env.SKILLJACK_CATALOG;
+    } else {
+      process.env.SKILLJACK_CATALOG = originalEnv;
+    }
+  });
+
+  it("defaults to instructions when nothing is set", () => {
+    process.argv = ["node", "script.js"];
+    delete process.env.SKILLJACK_CATALOG;
+    expect(getCatalogMode()).toBe("instructions");
+  });
+
+  it("reads --catalog=instructions from argv", () => {
+    process.argv = ["node", "script.js", "--catalog=instructions"];
+    expect(getCatalogMode()).toBe("instructions");
+  });
+
+  it("reads --catalog=tool-description from argv", () => {
+    process.argv = ["node", "script.js", "--catalog=tool-description"];
+    expect(getCatalogMode()).toBe("tool-description");
+  });
+
+  it("reads SKILLJACK_CATALOG env var", () => {
+    process.argv = ["node", "script.js"];
+    process.env.SKILLJACK_CATALOG = "instructions";
+    expect(getCatalogMode()).toBe("instructions");
+  });
+
+  it("prefers CLI flag over env var", () => {
+    process.argv = ["node", "script.js", "--catalog=tool-description"];
+    process.env.SKILLJACK_CATALOG = "instructions";
+    expect(getCatalogMode()).toBe("tool-description");
+  });
+
+  it("is case insensitive", () => {
+    process.argv = ["node", "script.js", "--catalog=INSTRUCTIONS"];
+    expect(getCatalogMode()).toBe("instructions");
+  });
+
+  it("warns and falls back to instructions on unknown values", () => {
+    process.argv = ["node", "script.js", "--catalog=both"];
+    expect(getCatalogMode()).toBe("instructions");
+    expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Unknown catalog mode"));
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,8 +27,8 @@ import chokidar from "chokidar";
 import * as fs from "node:fs";
 import * as path from "node:path";
 import { fileURLToPath } from "node:url";
-import { discoverSkills, createSkillMap, applyInvocationOverrides, SkillSource, DEFAULT_SKILL_SOURCE, BUNDLED_SKILL_SOURCE, warnLargeSkillCount, generateInstructions, getModelInvocableSkills } from "./skill-discovery.js";
-import { registerSkillTool, getToolDescription, SkillState } from "./skill-tool.js";
+import { discoverSkills, createSkillMap, applyInvocationOverrides, SkillSource, DEFAULT_SKILL_SOURCE, BUNDLED_SKILL_SOURCE, warnLargeSkillCount } from "./skill-discovery.js";
+import { registerSkillTool, getToolDescription, getServerInstructions, SkillState, CatalogMode } from "./skill-tool.js";
 import { registerSkillResources } from "./skill-resources.js";
 import { registerSkillPrompts, refreshPrompts, PromptRegistry } from "./skill-prompts.js";
 import { startHttpServer } from "./http-transport.js";
@@ -50,7 +50,7 @@ import {
   getRepoCachePath,
 } from "./github-config.js";
 import { syncAllRepos, SyncOptions } from "./github-sync.js";
-import { createPollingManager, PollingManager } from "./github-polling.js";
+import { createPollingManager } from "./github-polling.js";
 import {
   isWellKnownUrl,
   parseWellKnownUrl,
@@ -65,10 +65,7 @@ import {
   syncAllWellKnown,
   SyncOptions as WellKnownSyncOptions,
 } from "./well-known-sync.js";
-import {
-  createWellKnownPollingManager,
-  PollingManager as WellKnownPollingManager,
-} from "./well-known-polling.js";
+import { createWellKnownPollingManager } from "./well-known-polling.js";
 
 /**
  * Subdirectories to check for skills within the configured directory.
@@ -216,6 +213,29 @@ export function getStaticMode(): boolean {
 
   // Check config file (lowest priority)
   return getStaticModeFromConfig();
+}
+
+/**
+ * Resolve which channel carries the skill catalog (see CatalogMode in
+ * skill-tool.ts — exactly one channel, never both). Priority: `--catalog=<mode>`
+ * (single token so it isn't parsed as a skill directory) > SKILLJACK_CATALOG
+ * env var > "instructions". Unknown values warn and fall back to the default.
+ */
+export function getCatalogMode(): CatalogMode {
+  const args = process.argv.slice(2);
+  const flag = args.find((a) => a.startsWith("--catalog="));
+  const raw = flag ? flag.slice("--catalog=".length) : process.env.SKILLJACK_CATALOG;
+  if (!raw) {
+    return "instructions";
+  }
+  const value = raw.toLowerCase();
+  if (value === "tool-description" || value === "instructions") {
+    return value;
+  }
+  console.error(
+    `Unknown catalog mode "${raw}" (expected tool-description | instructions); using "instructions"`
+  );
+  return "instructions";
 }
 
 /**
@@ -393,13 +413,14 @@ const SKILL_REFRESH_DEBOUNCE_MS = 500;
  * @param promptRegistry - For refreshing skill prompts
  * @param subscriptionManager - For refreshing resource subscriptions
  */
-function refreshSkills(
-  skillsDirs: string[],
-  server: McpServer,
-  skillTool: RegisteredTool,
-  promptRegistry: PromptRegistry,
-  subscriptionManager: SubscriptionManager
-): void {
+/**
+ * Re-discover skills and swap skillState.skillMap — the transport-agnostic
+ * core of a refresh. Used directly by the HTTP path (where each request reads
+ * skillState fresh, so a state swap is all a refresh needs) and by
+ * refreshSkills() on the stdio path (which adds the server-bound updates:
+ * tool description, prompts, subscriptions, notifications).
+ */
+function refreshSkillState(skillsDirs: string[]): void {
   console.error("Refreshing skills...");
 
   // Re-discover all skills using current source map
@@ -415,10 +436,23 @@ function refreshSkills(
 
   console.error(`Skills refreshed: ${oldCount} -> ${skills.length} skill(s)`);
   warnLargeSkillCount(skills.length);
+}
 
-  // Update the skill tool description with new instructions
+function refreshSkills(
+  skillsDirs: string[],
+  server: McpServer,
+  skillTool: RegisteredTool,
+  promptRegistry: PromptRegistry,
+  subscriptionManager: SubscriptionManager
+): void {
+  refreshSkillState(skillsDirs);
+
+  // Update the skill tool description with new instructions. In
+  // catalog=instructions mode this is usage-only (no skill list) — the catalog
+  // lives in server instructions, which the SDK freezes at construction, so
+  // dynamic skill changes cannot reach the client until restart in that mode.
   skillTool.update({
-    description: getToolDescription(skillState),
+    description: getToolDescription(skillState, getCatalogMode()),
   });
 
   // Refresh prompts to match new skill state
@@ -454,17 +488,13 @@ function refreshSkills(
  * Watches for SKILL.md additions, modifications, and deletions.
  *
  * @param skillsDirs - The configured skill directories
- * @param server - The MCP server instance
- * @param skillTool - The registered skill tool to update
- * @param promptRegistry - For refreshing skill prompts
- * @param subscriptionManager - For refreshing subscriptions
+ * @param onRefresh - Called (debounced) when skills change. The stdio path
+ *   passes refreshSkills (state + server updates + notifications); the HTTP
+ *   path passes refreshSkillState (state only — requests read it fresh).
  */
 function watchSkillDirectories(
   skillsDirs: string[],
-  server: McpServer,
-  skillTool: RegisteredTool,
-  promptRegistry: PromptRegistry,
-  subscriptionManager: SubscriptionManager
+  onRefresh: () => void
 ): void {
   let refreshTimeout: NodeJS.Timeout | null = null;
 
@@ -474,7 +504,7 @@ function watchSkillDirectories(
     }
     refreshTimeout = setTimeout(() => {
       refreshTimeout = null;
-      refreshSkills(skillsDirs, server, skillTool, promptRegistry, subscriptionManager);
+      onRefresh();
     }, SKILL_REFRESH_DEBOUNCE_MS);
   };
 
@@ -549,6 +579,65 @@ function watchSkillDirectories(
     console.error(`Directory removed: ${dirPath}`);
     debouncedRefresh();
   });
+}
+
+/**
+ * Start GitHub / well-known polling managers that re-sync remote sources and
+ * invoke onRefresh when updates land. Shared by the stdio and HTTP paths —
+ * only the refresh callback differs (stdio also pushes notifications).
+ */
+function startRemoteSourcePolling(
+  githubConfig: ReturnType<typeof getGitHubConfig>,
+  wellKnownConfig: ReturnType<typeof getWellKnownConfig>,
+  onRefresh: () => void
+): void {
+  if (currentGithubSpecs.length > 0 && githubConfig.pollIntervalMs > 0) {
+    const syncOptions: SyncOptions = {
+      cacheDir: githubConfig.cacheDir,
+      token: githubConfig.token,
+      shallowClone: true,
+    };
+
+    const pollingManager = createPollingManager(currentGithubSpecs, syncOptions, {
+      intervalMs: githubConfig.pollIntervalMs,
+      onUpdate: (spec) => {
+        console.error(`GitHub update detected for ${spec.owner}/${spec.repo}`);
+        onRefresh();
+      },
+      onError: (spec, error) => {
+        console.error(`GitHub polling error for ${spec.owner}/${spec.repo}: ${error.message}`);
+      },
+    });
+
+    pollingManager.start();
+  }
+
+  if (currentWellKnownSpecs.length > 0 && wellKnownConfig.pollIntervalMs > 0) {
+    const wkSyncOptions: WellKnownSyncOptions = {
+      cacheDir: wellKnownConfig.cacheDir,
+      maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
+      maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
+      allowedOrigins: wellKnownConfig.allowedOrigins,
+      allowHttp: wellKnownConfig.allowHttp,
+    };
+
+    const wellKnownPollingManager = createWellKnownPollingManager(
+      currentWellKnownSpecs,
+      wkSyncOptions,
+      {
+        intervalMs: wellKnownConfig.pollIntervalMs,
+        onUpdate: (spec) => {
+          console.error(`Well-known update detected for ${spec.origin}`);
+          onRefresh();
+        },
+        onError: (spec, error) => {
+          console.error(`Well-known polling error for ${spec.origin}: ${error.message}`);
+        },
+      }
+    );
+
+    wellKnownPollingManager.start();
+  }
 }
 
 /**
@@ -710,12 +799,25 @@ async function main() {
   warnLargeSkillCount(skills.length);
 
   // HTTP transport: serve the core skill surface over stateless HTTP and return.
-  // The stdio path below (UI config/display tools, remote-source polling, file
-  // watching, dynamic refresh notifications) is intentionally skipped in HTTP
-  // mode — stateless HTTP cannot push notifications. Restart to pick up changes.
+  // Discovery-on-change works the same as stdio — file watchers and remote-source
+  // polling refresh skillState, and every request (including each new client's
+  // initialize, which carries the instructions catalog) reads that state fresh.
+  // What stateless HTTP cannot do is *push*: no listChanged/resources/updated
+  // notifications, so already-connected clients see changes on their next
+  // request rather than being told to refresh. UI config/display tools remain
+  // stdio-only.
   const httpPort = getHttpPort();
+  const catalogMode = getCatalogMode();
   if (httpPort !== null) {
-    await startHttpServer(httpPort, skillState);
+    if (!isStatic) {
+      if (currentSkillsDirs.length > 0) {
+        watchSkillDirectories(currentSkillsDirs, () => refreshSkillState(currentSkillsDirs));
+      }
+      startRemoteSourcePolling(githubConfig, wellKnownConfig, () =>
+        refreshSkillState(currentSkillsDirs)
+      );
+    }
+    await startHttpServer(httpPort, skillState, catalogMode);
     return;
   }
 
@@ -723,13 +825,12 @@ async function main() {
   // In static mode, disable listChanged for tools/prompts (skills list is frozen)
   // Resource subscriptions remain dynamic for individual skill file watching
   //
-  // Server instructions: XML catalog of model-invocable skills. Some clients
-  // (e.g. Claude Agent SDK 0.2.x without the claude_code preset) route skill
-  // awareness via server instructions rather than the skill tool's description,
-  // so we provide both. Instructions are set once at construction; dynamic skill
-  // changes are still delivered via the load-skill tool's description + tools/listChanged.
-  const initialSkills = Array.from(skillState.skillMap.values());
-  const initialInstructions = generateInstructions(getModelInvocableSkills(initialSkills));
+  // The skill catalog goes through exactly ONE channel (never both): server
+  // instructions (default; survives tool-search deferral, but instructions are
+  // set once at construction, so the catalog is frozen until restart on stdio)
+  // or the load-skill tool description (`--catalog=tool-description`; dynamic
+  // via tools/listChanged, but deferred out of context under tool search).
+  const initialInstructions = getServerInstructions(skillState, catalogMode);
 
   const server = new McpServer(
     {
@@ -746,12 +847,12 @@ async function main() {
           "io.modelcontextprotocol/skills": {},
         },
       },
-      instructions: initialInstructions,
+      ...(initialInstructions !== undefined && { instructions: initialInstructions }),
     }
   );
 
   // Register tools, resources, and prompts
-  const skillTool = registerSkillTool(server, skillState);
+  const skillTool = registerSkillTool(server, skillState, catalogMode);
   registerSkillResources(server, skillState);
   const promptRegistry = registerSkillPrompts(server, skillState);
 
@@ -867,65 +968,15 @@ async function main() {
     });
   }
 
-  // Set up file watchers for skill directory changes (skip in static mode)
-  if (!isStatic && currentSkillsDirs.length > 0) {
-    watchSkillDirectories(currentSkillsDirs, server, skillTool, promptRegistry, subscriptionManager);
-  }
-
-  // Set up GitHub polling for updates (skip in static mode)
-  let pollingManager: PollingManager | null = null;
-  if (!isStatic && currentGithubSpecs.length > 0 && githubConfig.pollIntervalMs > 0) {
-    const syncOptions: SyncOptions = {
-      cacheDir: githubConfig.cacheDir,
-      token: githubConfig.token,
-      shallowClone: true,
-    };
-
-    pollingManager = createPollingManager(currentGithubSpecs, syncOptions, {
-      intervalMs: githubConfig.pollIntervalMs,
-      onUpdate: (spec, result) => {
-        console.error(`GitHub update detected for ${spec.owner}/${spec.repo}`);
-        refreshSkills(currentSkillsDirs, server, skillTool, promptRegistry, subscriptionManager);
-      },
-      onError: (spec, error) => {
-        console.error(`GitHub polling error for ${spec.owner}/${spec.repo}: ${error.message}`);
-      },
-    });
-
-    pollingManager.start();
-  }
-
-  // Set up well-known polling for updates (skip in static mode)
-  let wellKnownPollingManager: WellKnownPollingManager | null = null;
-  if (
-    !isStatic &&
-    currentWellKnownSpecs.length > 0 &&
-    wellKnownConfig.pollIntervalMs > 0
-  ) {
-    const wkSyncOptions: WellKnownSyncOptions = {
-      cacheDir: wellKnownConfig.cacheDir,
-      maxArtifactBytes: wellKnownConfig.maxArtifactBytes,
-      maxUnpackedBytes: wellKnownConfig.maxUnpackedBytes,
-      allowedOrigins: wellKnownConfig.allowedOrigins,
-      allowHttp: wellKnownConfig.allowHttp,
-    };
-
-    wellKnownPollingManager = createWellKnownPollingManager(
-      currentWellKnownSpecs,
-      wkSyncOptions,
-      {
-        intervalMs: wellKnownConfig.pollIntervalMs,
-        onUpdate: (spec, _result) => {
-          console.error(`Well-known update detected for ${spec.origin}`);
-          refreshSkills(currentSkillsDirs, server, skillTool, promptRegistry, subscriptionManager);
-        },
-        onError: (spec, error) => {
-          console.error(`Well-known polling error for ${spec.origin}: ${error.message}`);
-        },
-      }
-    );
-
-    wellKnownPollingManager.start();
+  // Set up file watchers and remote-source polling (skip in static mode).
+  // On stdio a refresh also updates the tool/prompts and pushes notifications.
+  if (!isStatic) {
+    const refreshAll = () =>
+      refreshSkills(currentSkillsDirs, server, skillTool, promptRegistry, subscriptionManager);
+    if (currentSkillsDirs.length > 0) {
+      watchSkillDirectories(currentSkillsDirs, refreshAll);
+    }
+    startRemoteSourcePolling(githubConfig, wellKnownConfig, refreshAll);
   }
 
   // Connect via stdio transport

--- a/src/skill-tool.test.ts
+++ b/src/skill-tool.test.ts
@@ -1,17 +1,17 @@
 import { describe, it, expect } from "vitest";
 import * as path from "node:path";
-import { getToolDescription, isPathWithinBase, listSkillFiles } from "./skill-tool.js";
+import { getToolDescription, getServerInstructions, isPathWithinBase, listSkillFiles } from "./skill-tool.js";
 import { createTestSkill, createTestSkillState } from "./__test-helpers__/helpers.js";
 
 // Path to fixtures
 const FIXTURES_DIR = path.resolve(__dirname, "__fixtures__", "skills");
 
 describe("getToolDescription", () => {
-  it("includes skill list for model-invocable skills", () => {
+  it("includes skill list for model-invocable skills in tool-description mode", () => {
     const state = createTestSkillState([
       createTestSkill({ name: "my-skill", description: "Does things", effectiveAssistantInvocable: true }),
     ]);
-    const desc = getToolDescription(state);
+    const desc = getToolDescription(state, "tool-description");
     expect(desc).toContain("Load a skill");
     expect(desc).toContain("<name>my-skill</name>");
     expect(desc).toContain("<description>Does things</description>");
@@ -22,9 +22,49 @@ describe("getToolDescription", () => {
       createTestSkill({ name: "visible", effectiveAssistantInvocable: true }),
       createTestSkill({ name: "hidden", effectiveAssistantInvocable: false }),
     ]);
-    const desc = getToolDescription(state);
+    const desc = getToolDescription(state, "tool-description");
     expect(desc).toContain("<name>visible</name>");
     expect(desc).not.toContain("<name>hidden</name>");
+  });
+
+  it("omits the skill list in instructions mode (the default) but keeps usage guidance", () => {
+    const state = createTestSkillState([
+      createTestSkill({ name: "my-skill", effectiveAssistantInvocable: true }),
+    ]);
+    for (const desc of [getToolDescription(state, "instructions"), getToolDescription(state)]) {
+      expect(desc).toContain("Load a skill");
+      expect(desc).not.toContain("<available_skills>");
+      expect(desc).not.toContain("<name>my-skill</name>");
+    }
+  });
+});
+
+describe("getServerInstructions", () => {
+  const state = () =>
+    createTestSkillState([
+      createTestSkill({ name: "my-skill", description: "Does things", effectiveAssistantInvocable: true }),
+    ]);
+
+  it("returns undefined in tool-description mode", () => {
+    expect(getServerInstructions(state(), "tool-description")).toBeUndefined();
+  });
+
+  it("returns usage preamble + catalog in instructions mode (the default)", () => {
+    for (const instructions of [getServerInstructions(state(), "instructions"), getServerInstructions(state())]) {
+      expect(instructions).toContain("`load-skill`");
+      expect(instructions).toContain("<name>my-skill</name>");
+      expect(instructions).toContain("<description>Does things</description>");
+    }
+  });
+
+  it("filters non-model-invocable skills", () => {
+    const mixed = createTestSkillState([
+      createTestSkill({ name: "visible", effectiveAssistantInvocable: true }),
+      createTestSkill({ name: "hidden", effectiveAssistantInvocable: false }),
+    ]);
+    const instructions = getServerInstructions(mixed, "instructions");
+    expect(instructions).toContain("<name>visible</name>");
+    expect(instructions).not.toContain("<name>hidden</name>");
   });
 });
 

--- a/src/skill-tool.ts
+++ b/src/skill-tool.ts
@@ -24,6 +24,21 @@ export interface SkillState {
 }
 
 /**
+ * Which channel carries the <available_skills> catalog to the client. The
+ * catalog goes through exactly one channel — never both.
+ *
+ * - "instructions" (default): catalog in server instructions (delivered in the
+ *   initialize handshake, so it survives tool-search deferral; frozen at
+ *   construction on stdio — the SDK has no way to update instructions).
+ * - "tool-description": catalog in the load-skill tool description
+ *   (dynamic via tools/listChanged, but invisible to clients that defer MCP
+ *   tool descriptions out of context, e.g. Claude Code tool search).
+ *
+ * Set via `--catalog=<mode>` or SKILLJACK_CATALOG (see getCatalogMode in index.ts).
+ */
+export type CatalogMode = "tool-description" | "instructions";
+
+/**
  * Input schema for the skill tool.
  */
 const SkillSchema = z.object({
@@ -49,29 +64,74 @@ const SkillSchema = z.object({
  * Generate the full tool description including usage guidance and skill list.
  * Exported so index.ts can use it when refreshing skills.
  */
-export function getToolDescription(skillState: SkillState): string {
-  const usage =
-    "Load a skill's full instructions. Returns the complete SKILL.md content " +
-    "with step-by-step guidance, examples, and file references to follow.\n\n" +
-    "IMPORTANT: When a skill is relevant to the user's task, you must invoke this tool " +
-    "IMMEDIATELY as your first action. NEVER just announce or mention a skill without " +
-    "actually calling this tool. This is a BLOCKING REQUIREMENT: invoke this tool BEFORE " +
-    "generating any other response about the task.\n\n";
+const LOAD_SKILL_USAGE =
+  "Load a skill's full instructions. Returns the complete SKILL.md content " +
+  "with step-by-step guidance, examples, and file references to follow.\n\n" +
+  "IMPORTANT: When a skill is relevant to the user's task, you must invoke this tool " +
+  "IMMEDIATELY as your first action. NEVER just announce or mention a skill without " +
+  "actually calling this tool. This is a BLOCKING REQUIREMENT: invoke this tool BEFORE " +
+  "generating any other response about the task.\n\n";
 
+export function getToolDescription(
+  skillState: SkillState,
+  catalogMode: CatalogMode = "instructions"
+): string {
+  if (catalogMode === "instructions") {
+    // Catalog lives in server instructions; keep the description to usage only.
+    return LOAD_SKILL_USAGE.trimEnd();
+  }
   const allSkills = Array.from(skillState.skillMap.values());
   const modelInvocableSkills = getModelInvocableSkills(allSkills);
+  return LOAD_SKILL_USAGE + generateInstructions(modelInvocableSkills);
+}
+
+/**
+ * Server-instructions text for `--catalog=instructions` mode: the same usage
+ * preamble + <available_skills> catalog that normally lives in the load-skill
+ * tool description. The preamble names the tool because under tool search the
+ * model may never see the tool description itself.
+ */
+export function getCatalogInstructions(skillState: SkillState): string {
+  const allSkills = Array.from(skillState.skillMap.values());
+  const modelInvocableSkills = getModelInvocableSkills(allSkills);
+  const usage =
+    "This server's `load-skill` tool loads a skill's full instructions. It returns " +
+    "the complete SKILL.md content with step-by-step guidance, examples, and file " +
+    "references to follow.\n\n" +
+    "IMPORTANT: When a skill is relevant to the user's task, you must invoke the " +
+    "`load-skill` tool IMMEDIATELY as your first action. NEVER just announce or " +
+    "mention a skill without actually calling the tool. This is a BLOCKING " +
+    "REQUIREMENT: invoke `load-skill` BEFORE generating any other response about " +
+    "the task.\n\n";
   return usage + generateInstructions(modelInvocableSkills);
+}
+
+/**
+ * Server `instructions` value for a given catalog mode, or undefined to omit
+ * the field. Used by both server construction sites (index.ts stdio,
+ * http-transport.ts). Only "instructions" mode emits instructions — the
+ * catalog is never delivered through both channels at once.
+ */
+export function getServerInstructions(
+  skillState: SkillState,
+  catalogMode: CatalogMode = "instructions"
+): string | undefined {
+  if (catalogMode === "instructions") {
+    return getCatalogInstructions(skillState);
+  }
+  return undefined;
 }
 
 export function registerSkillTool(
   server: McpServer,
-  skillState: SkillState
+  skillState: SkillState,
+  catalogMode: CatalogMode = "instructions"
 ): RegisteredTool {
   const skillTool = server.registerTool(
     "load-skill",
     {
       title: "Load Skill",
-      description: getToolDescription(skillState),
+      description: getToolDescription(skillState, catalogMode),
       inputSchema: SkillSchema,
       annotations: {
         readOnlyHint: true,


### PR DESCRIPTION
## Summary

- **BREAKING — single catalog channel:** the `<available_skills>` catalog now goes through exactly one channel, selected by `--catalog=<instructions|tool-description>` / `SKILLJACK_CATALOG`, never both. The old always-on dual delivery (instructions + tool description) is removed.
- **`instructions` is the new default:** server instructions arrive in the `initialize` handshake, so the catalog reaches the model even with Claude Code tool search / deferred tool loading enabled — skill auto-activation now works out of the box on default modern clients (issue #78). `tool-description` mode remains available (dynamic via `tools/listChanged`) but requires `ENABLE_TOOL_SEARCH=false`.
- **HTTP discovery-on-change:** HTTP mode now runs the same file watchers + GitHub/well-known polling as stdio, wired to a new state-only `refreshSkillState()`. Every request reads skillState fresh, so new connections always get a current catalog. (Stateless HTTP still can't push notifications; on stdio, instructions mode freezes the catalog until restart since the SDK sets instructions at construction.)
- **Eval harness knobs:** `--catalog=` (forwarded to the server under test) and `--tool-search=on|off` (sets `ENABLE_TOOL_SEARCH` explicitly both ways); both recorded in result JSON.
- Docs updated throughout: README, CLAUDE.md, evals/README, skilljack-docs skill.

## Eval evidence (agent-sdk 0.3.201, claude-sonnet-4-6, two batches)

| Catalog | Tool search | code-style | template-generator | xlsx-openpyxl |
|---|---|---|---|---|
| instructions (default) | **on** | PASS | PASS (incl. resource load) | PASS |
| tool-description | on | FAIL (control — description deferred) | — | — |
| tool-description | off | PASS (regression) | — | — |

## Test plan

- [x] `npm run build` clean, `npm test` 246/246 (new: `getCatalogMode` parsing, per-mode `getToolDescription`/`getServerInstructions`, per-mode HTTP `initialize` instructions, HTTP freshness across connections)
- [x] End-to-end smoke: SKILL.md added while `--http=0` server runs appears in a new client's `initialize` instructions
- [x] Eval batches above

🤖 Generated with [Claude Code](https://claude.com/claude-code)