### PR TITLE
Persist eval metrics in result summaries + document catalog-mode cost findings

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -39,6 +39,8 @@ npm run eval -- --task=code-style --mode=mcp --catalog=tool-description --tool-s
 
 **Result (2026-07-05, agent-sdk 0.3.201, claude-sonnet-4-6):** the instructions channel survives tool search — this is why it became the default. With the default catalog (no `--catalog` flag) and `--tool-search=on`, all 3 tasks pass (code-style, template-generator, xlsx-openpyxl — all of which fail in tool-description mode with tool search on); the tool-description + tool-search-on control failed as expected; tool-description + tool-search-off also passes. Reproduced across two batches, including one exercising the HTTP discovery-on-change path.
 
+**Caching/cost (2026-07-06, 8-cell matrix, 1 rep/cell):** the default (instructions + tool search ON) is also the cheapest *passing* configuration by ~3.5–6× ($0.15–0.21 vs $0.73–0.94 per run). The cost driver is `ENABLE_TOOL_SEARCH=off`, not the catalog channel: with tool search off, all tool definitions load upfront (~120–144k cache-creation tokens per run) regardless of catalog mode. Token/cache/cost metrics are persisted per run in both the session log (`evals/logs/`) and the result summary (`evals/results/`). Full table: [issue #78](https://github.com/olaservo/skilljack-mcp/issues/78).
+
 ## Running Evals
 
 ```bash

--- a/evals/eval.ts
+++ b/evals/eval.ts
@@ -346,9 +346,10 @@ async function main() {
     printEvalResult(evalResult, taskName, taskConfig.evalConfig);
 
     // Display and save metrics (only for SDK modes)
+    let metrics: ReturnType<typeof createMetricsData> | undefined;
     if (resultMessage && mode !== "cli-local") {
       displayMetrics(resultMessage, startTime);
-      const metrics = createMetricsData(resultMessage, taskName, startTime);
+      metrics = createMetricsData(resultMessage, taskName, startTime);
       logger.setMetrics(metrics);
     }
 
@@ -358,7 +359,7 @@ async function main() {
     console.log(`Human-readable log: ${logPath.replace('.json', '.md')}`);
 
     // Save result summary
-    await saveResultSummary(taskName, evalResult, logger.getSessionId(), taskConfig.evalConfig, mode, catalog, toolSearch);
+    await saveResultSummary(taskName, evalResult, logger.getSessionId(), taskConfig.evalConfig, mode, catalog, toolSearch, metrics);
 
     // Cleanup local skills if in local, cli-local, or mcp+local mode
     if (mode === "local" || mode === "cli-local" || mode === "mcp+local") {
@@ -381,7 +382,8 @@ async function saveResultSummary(
   evalConfig: EvalConfig,
   mode: EvalMode,
   catalog: CatalogMode | undefined,
-  toolSearch: ToolSearchSetting
+  toolSearch: ToolSearchSetting,
+  metrics?: ReturnType<typeof createMetricsData>
 ): Promise<void> {
   const resultsDir = './evals/results';
   await fs.mkdir(resultsDir, { recursive: true });
@@ -399,7 +401,8 @@ async function saveResultSummary(
     toolSearch,
     sessionId,
     passed,
-    results: evalResult
+    results: evalResult,
+    metrics
   };
 
   const filename = `${sessionId}.json`;


### PR DESCRIPTION
## Summary
- Copy the per-run `MetricsData` (input/output tokens, cache read/creation, cost, turns) into the `evals/results/<sessionId>.json` summary so each run is self-contained — previously metrics only lived in the session log, requiring correlation by sessionId.
- Add the 2026-07-06 caching/cost matrix findings to `evals/README.md`: the default catalog mode (instructions + tool search ON) is the cheapest passing configuration by ~3.5–6×; the cost driver is `ENABLE_TOOL_SEARCH=off`, not the catalog channel. Full table on #78.

## Test plan
- `npm test` (246 pass) — no src changes, evals harness only.
- Verified end-to-end by the 8-cell experiment matrix: every `evals/results/*.json` produced now contains the `metrics` object (spot-checked cache_read/cache_creation/cost against the session logs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)