### PR TITLE
Warn on stderr when the legacy tool-description catalog mode is selected

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -9,7 +9,7 @@ vi.mock("./skill-config.js", () => ({
 }));
 
 // Import after mocking
-import { classifyPaths, getStaticMode, getCatalogMode } from "./index.js";
+import { classifyPaths, getStaticMode, getCatalogMode, warnIfLegacyCatalogMode } from "./index.js";
 import { getStaticModeFromConfig } from "./skill-config.js";
 
 describe("classifyPaths", () => {
@@ -159,5 +159,23 @@ describe("getCatalogMode", () => {
     process.argv = ["node", "script.js", "--catalog=both"];
     expect(getCatalogMode()).toBe("instructions");
     expect(console.error).toHaveBeenCalledWith(expect.stringContaining("Unknown catalog mode"));
+  });
+});
+
+describe("warnIfLegacyCatalogMode", () => {
+  beforeEach(() => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  it("warns on stderr for tool-description mode", () => {
+    warnIfLegacyCatalogMode("tool-description");
+    expect(console.error).toHaveBeenCalledWith(
+      expect.stringContaining("legacy escape hatch and not recommended")
+    );
+  });
+
+  it("stays silent for instructions mode", () => {
+    warnIfLegacyCatalogMode("instructions");
+    expect(console.error).not.toHaveBeenCalled();
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,23 @@ export function getCatalogMode(): CatalogMode {
 }
 
 /**
+ * One-time startup warning for the legacy tool-description catalog channel.
+ * Called from main() (not getCatalogMode(), which runs again on refresh and
+ * per HTTP request) so it prints exactly once per process.
+ */
+export function warnIfLegacyCatalogMode(mode: CatalogMode): void {
+  if (mode !== "tool-description") {
+    return;
+  }
+  console.error(
+    "Warning: --catalog=tool-description is a legacy escape hatch and not recommended. " +
+      "Clients with tool search / deferred tool loading enabled (the modern Claude Code default) keep the load-skill description — and the skill catalog inside it — out of model context, so skills won't auto-activate unless the client sets ENABLE_TOOL_SEARCH=false. " +
+      "Each catalog refresh also invalidates the client's entire prompt cache, since tool definitions sit at the top of the cached prompt prefix. " +
+      "Prefer the default instructions mode. See https://github.com/olaservo/skilljack-mcp/issues/78"
+  );
+}
+
+/**
  * Resolve the HTTP port if HTTP transport is requested, else null (stdio).
  *
  * Enabled via `--http` / `--http=<port>` (single token so it isn't parsed as a
@@ -808,6 +825,7 @@ async function main() {
   // stdio-only.
   const httpPort = getHttpPort();
   const catalogMode = getCatalogMode();
+  warnIfLegacyCatalogMode(catalogMode);
   if (httpPort !== null) {
     if (!isStatic) {
       if (currentSkillsDirs.length > 0) {


### PR DESCRIPTION
## Summary
Follow-up to #82 (docs demotion): emit a one-time stderr warning at startup when `--catalog=tool-description` / `SKILLJACK_CATALOG=tool-description` is selected, explaining why the mode is not recommended (deferred out of context under tool search unless the client sets `ENABLE_TOOL_SEARCH=false`; every catalog refresh invalidates the client's entire prompt cache) and pointing at #78.

Implementation: new exported `warnIfLegacyCatalogMode(mode)` in `src/index.ts`, called once from `main()` right after the mode is resolved — deliberately not inside `getCatalogMode()`, which runs again on skill refresh and per HTTP request and would spam stderr.

## Test plan
- Two new unit tests in `src/index.test.ts` (warns for `tool-description`, silent for `instructions`) — 248 pass.
- End-to-end smoke: `node dist/index.js --catalog=tool-description --http=0 ./evals/skills` prints the warning once on stderr; the default mode prints nothing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)