### PR TITLE
chore: build on publish

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "node": ">=20.0.0"
   },
   "scripts": {
+    "prepublishOnly": "npm run build",
     "build": "npm run build:ui && npm run build:ui:display && tsc",
     "build:ui": "npm run typecheck:ui && vite build",
     "build:ui:display": "cross-env INPUT=skill-display.html vite build --emptyOutDir false",


### PR DESCRIPTION
`dist/` is gitignored and nothing rebuilt it on the publish path, so publishing from a clean checkout (or after `git clean`) would have shipped a tarball without `dist/`. Adds `prepublishOnly: npm run build`.

The existing `files` allowlist is already correct — no change needed there.

Verified with `npm publish --dry-run` after deleting `dist/`: the hook rebuilds it and the tarball is the expected 40 files / 1.0 MB unpacked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)